### PR TITLE
fix: refine autocomplete item hover styling

### DIFF
--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -182,9 +182,16 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 		}
 
 		.ui-autocomplete.search-results .ui-menu-item {
-			padding: 8px 12px;
+			padding: 1px;
 			cursor: pointer;
 			border-bottom: 1px solid #eee;
+		}
+
+		.ui-autocomplete.search-results .ui-menu-item:hover a {
+			margin: -1px;
+			border: 1px solid #74b2e2;
+			background: #e4f1fb;
+			color: #0070a3;
 		}
 
 		.ui-autocomplete.search-results .ui-menu-item a,


### PR DESCRIPTION
Before:
<img width="295" height="382" alt="image" src="https://github.com/user-attachments/assets/bd89adac-d081-493a-ac9f-b1aa78e72d9d" />

After:
<img width="292" height="362" alt="image" src="https://github.com/user-attachments/assets/7974c29e-1365-4966-b6d5-663a5d2687b6" />
