### PR TITLE
perf: strip bopomofo from search input

### DIFF
--- a/src/components/searchbox.tsx
+++ b/src/components/searchbox.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { prefetchDictionaryEntry } from '../utils/dictionary-cache';
+import { removeBopomofo } from '../utils/bopomofo-pinyin-utils'
 
 type Lang = 'a' | 't' | 'h' | 'c';
 
@@ -116,7 +117,7 @@ function extractTermFromPath(pathname: string): string {
 }
 
 function resolveSearchInput(input: string, fallbackLang: Lang): { lang: Lang; term: string } | null {
-	const trimmed = input.trim();
+	const trimmed = removeBopomofo(input.trim());
 	if (!trimmed) return null;
 
 	const { lang: parsedLang, cleanTerm } = parseSearchTerm(trimmed);

--- a/src/utils/bopomofo-pinyin-utils.ts
+++ b/src/utils/bopomofo-pinyin-utils.ts
@@ -224,3 +224,8 @@ export function formatPinyin(pinyin: string): string {
   if (!pinyin) return '';
   return pinyin.replace(/([āáǎàōóǒòēéěèīíǐìūúǔùǖǘǚǜ])/g, '<span class="tone">$1</span>');
 }
+
+// 去除注音符號
+export function removeBopomofo(str: string) {
+  return str.replace(/[\u3105-\u312F\u31A0-\u31BF\u02D9\u02CA\u02C7\u02CB]/g, '');
+}


### PR DESCRIPTION
目前搜尋框在注音打字時，會持續將含有注音符號的字串送出搜尋

例如要查 "今天"，透過注音打字將如以下順序送 API 查詢
- ㄐ
- ㄐㄧ
- ㄐㄧㄣ
- 今
- 今ㄊ
- 今ㄊㄧ
- 今ㄊㄧㄢ
- 今天

這個 PR 在搜尋前先過濾注音，減少非必要的搜尋，以 "今天" 一詞為例，API 查詢會簡化為

- 今
- 今天