### PR TITLE
Fix IME arrow key handling in searchbox

### DIFF
--- a/src/components/searchbox.tsx
+++ b/src/components/searchbox.tsx
@@ -202,6 +202,7 @@ export function SearchBox({ currentLang }: SearchBoxProps) {
 	const suggestionRefs = useRef<Array<HTMLAnchorElement | null>>([]);
 	const requestIdRef = useRef(0);
 	const blurTimerRef = useRef<number | null>(null);
+	const isComposingRef = useRef(false);
 	const [searchValue, setSearchValue] = useState('');
 	const [suggestions, setSuggestions] = useState<SuggestionItem[]>([]);
 	const [loadingSuggestions, setLoadingSuggestions] = useState(false);
@@ -345,6 +346,16 @@ export function SearchBox({ currentLang }: SearchBoxProps) {
 		[syncRouteWithInput]
 	);
 
+	// 處理輸入法開始
+	const handleInputCompositionStart = useCallback(() => {
+		isComposingRef.current = true;
+	}, []);
+
+	// 處理輸入法結束
+	const handleInputCompositionEnd = useCallback(() => {
+		isComposingRef.current = false;
+	}, []);
+
 	// container 取得 focus（任何子元素 focus 都算）
 	const handleContainerFocus = useCallback(() => {
 		if (blurTimerRef.current !== null) {
@@ -430,6 +441,10 @@ export function SearchBox({ currentLang }: SearchBoxProps) {
 	// 輸入框鍵盤事件
 	const handleInputKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLInputElement>) => {
+			const nativeEvent = e.nativeEvent as KeyboardEvent;
+			const isImeNavigating = isComposingRef.current || nativeEvent.isComposing || nativeEvent.keyCode === 229;
+			if (isImeNavigating) return;
+
 			if (e.key === 'ArrowDown' && !isMobileViewport) {
 				if (!loadingSuggestions && suggestions.length > 0) {
 					e.preventDefault();
@@ -480,6 +495,8 @@ export function SearchBox({ currentLang }: SearchBoxProps) {
 					placeholder="請輸入欲查詢的字詞"
 					value={searchValue}
 					onChange={handleInputChange}
+					onCompositionStart={handleInputCompositionStart}
+					onCompositionEnd={handleInputCompositionEnd}
 					onKeyDown={handleInputKeyDown}
 				/>
 			</form>


### PR DESCRIPTION
## 變更摘要

修正搜尋框在輸入法組字期間攔截 `ArrowUp` / `ArrowDown` 的問題。

在注音輸入法選字時，搜尋框原本會先處理方向鍵，導致 IME 選字流程被中斷。

在 `src/components/searchbox.tsx` 中加入輸入法組字狀態判斷，當輸入框仍在 composition 階段時，不攔截方向鍵事件。

Fixes #76 

## 測試方式

在搜尋框使用注音輸入，並按上下鍵：應該要維持在輸入法選單選字的狀態。

## 風險 / 相容性說明

只影響搜尋框在輸入法組字期間的方向鍵處理。