### PR TITLE
404 字圖頁新增鏤空列印與描寫練習(New feature hollow font)

### DIFF
--- a/src/components/CharacterImageView.tsx
+++ b/src/components/CharacterImageView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchDictionaryEntry, type DictionaryLang } from '../utils/dictionary-cache';
 
@@ -102,6 +102,45 @@ interface TermSegment {
   def: string;
 }
 
+interface DrawState {
+  drawing: boolean;
+  pointerId: number | null;
+  lastX: number;
+  lastY: number;
+}
+
+const SEGMENT_IMAGE_SIZE = 160;
+
+function setDrawingStyle(
+  context: CanvasRenderingContext2D,
+  ratio: number,
+  width: number,
+  height: number,
+): void {
+  context.setTransform(1, 0, 0, 1, 0, 0);
+  context.clearRect(0, 0, width * ratio, height * ratio);
+  context.setTransform(ratio, 0, 0, ratio, 0, 0);
+  context.lineCap = 'round';
+  context.lineJoin = 'round';
+  context.lineWidth = 3;
+  context.strokeStyle = 'rgba(27, 56, 89, 0.85)';
+  context.fillStyle = 'rgba(27, 56, 89, 0.85)';
+}
+
+function resetPracticeCanvas(canvas: HTMLCanvasElement, width: number, height: number): void {
+  const ratio = window.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.round(width * ratio));
+  canvas.height = Math.max(1, Math.round(height * ratio));
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  canvas.dataset.width = String(width);
+  canvas.dataset.height = String(height);
+
+  const context = canvas.getContext('2d');
+  if (!context) return;
+  setDrawingStyle(context, ratio, width, height);
+}
+
 function mergeEnglishTerms(terms: string[]): string[] {
   const merged: string[] = [];
   for (const term of terms) {
@@ -156,7 +195,11 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
   const [segments, setSegments] = useState<TermSegment[]>([]);
   const [shareSupported] = useState(() => typeof navigator !== 'undefined' && !!navigator.share);
   const [font, setFont] = useState(getStoredFont);
+  const [hollowMode, setHollowMode] = useState(true);
+  const canvasRefs = useRef<Record<string, HTMLCanvasElement>>({});
+  const drawStates = useRef<Record<string, DrawState>>({});
   const mergedTerms = useMemo(() => mergeEnglishTerms(terms), [terms]);
+  const mainImageSize = queryWord.length > 1 ? SEGMENT_IMAGE_SIZE : 240;
 
   const handleFontChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const next = e.target.value;
@@ -216,15 +259,159 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
     [navigate],
   );
 
-  return (
-    <div className="result charimg-result">
-      <center>
-        <img src={charImgUrl(queryWord, font)}
-          alt={queryWord}
-          style={{ width: queryWord.length > 1 ? 160 : 240 }}
-        />
+  const registerCanvas = useCallback(
+    (key: string, width: number, height: number) => (node: HTMLCanvasElement | null) => {
+      if (!node) {
+        delete canvasRefs.current[key];
+        delete drawStates.current[key];
+        return;
+      }
+      canvasRefs.current[key] = node;
+      resetPracticeCanvas(node, width, height);
+    },
+    [],
+  );
 
-        <div className="charimg-share" style={{ margin: 15 }}>
+  const drawPoint = useCallback((key: string, event: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRefs.current[key];
+    if (!canvas) return;
+    const state = drawStates.current[key];
+    if (!state?.drawing || state.pointerId !== event.pointerId) return;
+
+    const context = canvas.getContext('2d');
+    if (!context) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    context.beginPath();
+    context.moveTo(state.lastX, state.lastY);
+    context.lineTo(x, y);
+    context.stroke();
+    state.lastX = x;
+    state.lastY = y;
+  }, []);
+
+  const handleCanvasPointerDown = useCallback((key: string, event: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRefs.current[key];
+    if (!canvas) return;
+    event.preventDefault();
+    canvas.setPointerCapture(event.pointerId);
+
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    drawStates.current[key] = {
+      drawing: true,
+      pointerId: event.pointerId,
+      lastX: x,
+      lastY: y,
+    };
+
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    context.beginPath();
+    context.arc(x, y, 1.4, 0, Math.PI * 2);
+    context.fill();
+  }, []);
+
+  const handleCanvasPointerMove = useCallback(
+    (key: string, event: React.PointerEvent<HTMLCanvasElement>) => {
+      event.preventDefault();
+      drawPoint(key, event);
+    },
+    [drawPoint],
+  );
+
+  const finishDrawing = useCallback((key: string, event: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRefs.current[key];
+    const state = drawStates.current[key];
+    if (!state || !state.drawing || state.pointerId !== event.pointerId) return;
+    state.drawing = false;
+    state.pointerId = null;
+    if (canvas && canvas.hasPointerCapture(event.pointerId)) {
+      canvas.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const handleClearDrawings = useCallback(() => {
+    for (const canvas of Object.values(canvasRefs.current)) {
+      const width = Number(canvas.dataset.width || SEGMENT_IMAGE_SIZE);
+      const height = Number(canvas.dataset.height || SEGMENT_IMAGE_SIZE);
+      resetPracticeCanvas(canvas, width, height);
+    }
+  }, []);
+
+  const handlePrint = useCallback(() => {
+    window.print();
+  }, []);
+
+  return (
+    <div className={`result charimg-result${hollowMode ? ' charimg-hollow' : ''}`}>
+      <style>
+        {`
+          .charimg-result .charimg-controls {
+            margin: 15px 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            justify-content: center;
+          }
+
+          .charimg-result .charimg-practice-box {
+            position: relative;
+            display: inline-block;
+            line-height: 0;
+            user-select: none;
+          }
+
+          .charimg-result .charimg-draw-canvas {
+            position: absolute;
+            inset: 0;
+            background: transparent;
+            touch-action: none;
+            cursor: crosshair;
+          }
+
+          .charimg-result.charimg-hollow img.charimg-glyph {
+            filter: invert(100%) grayscale(100%);
+            opacity: .32;
+          }
+
+          @media print {
+            .charimg-result .charimg-controls {
+              display: none !important;
+            }
+            .charimg-result .charimg-draw-canvas {
+              display: none !important;
+            }
+          }
+        `}
+      </style>
+      <center>
+        <div
+          className="charimg-practice-box"
+          style={{ width: mainImageSize, height: mainImageSize }}
+        >
+          <img
+            className="charimg-glyph"
+            src={charImgUrl(queryWord, font)}
+            alt={queryWord}
+            style={{ width: mainImageSize, height: mainImageSize }}
+          />
+          <canvas
+            className="charimg-draw-canvas"
+            ref={registerCanvas(`main:${queryWord}`, mainImageSize, mainImageSize)}
+            onPointerDown={(event) => handleCanvasPointerDown(`main:${queryWord}`, event)}
+            onPointerMove={(event) => handleCanvasPointerMove(`main:${queryWord}`, event)}
+            onPointerUp={(event) => finishDrawing(`main:${queryWord}`, event)}
+            onPointerLeave={(event) => finishDrawing(`main:${queryWord}`, event)}
+            onPointerCancel={(event) => finishDrawing(`main:${queryWord}`, event)}
+          />
+        </div>
+
+        <div className="charimg-controls">
           <select
             id="font"
             value={font}
@@ -248,6 +435,30 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
             {' '}
             {shareSupported ? '分享' : '複製連結'}
           </button>
+          <button
+            className="btn btn-default charimg-print-btn"
+            title="列印目前字圖"
+            onClick={handlePrint}
+          >
+            <span className="icon-print" />
+            {' '}
+            列印字卡
+          </button>
+          <button
+            className="btn btn-default charimg-clear-btn"
+            title="清空描寫筆跡"
+            onClick={handleClearDrawings}
+          >
+            清除描寫
+          </button>
+          <label style={{ marginBottom: 0, display: 'inline-flex', gap: 4, alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={hollowMode}
+              onChange={(event) => setHollowMode(event.target.checked)}
+            />
+            鏤空字模式
+          </label>
         </div>
 
         <table
@@ -265,22 +476,23 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
             {segments.map((segment) => (
               <tr key={segment.part}>
                 <td style={{ verticalAlign: 'top', padding: 4 }}>
-                  {segment.href ? (
-                    <a
-                      href={segment.href}
-                      onClick={(e) => handleTermClick(e, segment.href!)}
-                    >
-                      <img src={charImgUrl(segment.part, font)}
-                        alt={segment.part}
-                        style={{ width: 160, height: 160 }}
-                      />
-                    </a>
-                  ) : (
-                    <img src={charImgUrl(segment.part, font)}
+                  <div className="charimg-practice-box" style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}>
+                    <img
+                      className="charimg-glyph"
+                      src={charImgUrl(segment.part, font)}
                       alt={segment.part}
-                      style={{ width: 160, height: 160 }}
+                      style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}
                     />
-                  )}
+                    <canvas
+                      className="charimg-draw-canvas"
+                      ref={registerCanvas(`segment:${segment.part}`, SEGMENT_IMAGE_SIZE, SEGMENT_IMAGE_SIZE)}
+                      onPointerDown={(event) => handleCanvasPointerDown(`segment:${segment.part}`, event)}
+                      onPointerMove={(event) => handleCanvasPointerMove(`segment:${segment.part}`, event)}
+                      onPointerUp={(event) => finishDrawing(`segment:${segment.part}`, event)}
+                      onPointerLeave={(event) => finishDrawing(`segment:${segment.part}`, event)}
+                      onPointerCancel={(event) => finishDrawing(`segment:${segment.part}`, event)}
+                    />
+                  </div>
                 </td>
                 <td
                   style={{

--- a/src/components/CharacterImageView.tsx
+++ b/src/components/CharacterImageView.tsx
@@ -386,6 +386,34 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
             .charimg-result .charimg-draw-canvas {
               display: none !important;
             }
+            .charimg-result table.moetext {
+              display: block;
+              max-width: 100% !important;
+              background: transparent !important;
+              border: 0 !important;
+              box-shadow: none !important;
+            }
+            .charimg-result table.moetext > tbody {
+              display: inline-flex;
+              flex-wrap: wrap;
+              align-items: flex-start;
+              gap: 8px;
+            }
+            .charimg-result table.moetext > tbody > tr {
+              display: inline-flex;
+              align-items: flex-start;
+              border: 1px solid #ddd;
+              padding: 4px;
+              break-inside: avoid;
+              page-break-inside: avoid;
+            }
+            .charimg-result table.moetext > tbody > tr > td {
+              padding: 0 !important;
+            }
+            .charimg-result table.moetext > tbody > tr > td:last-child {
+              padding-left: 8px !important;
+              max-width: 180px;
+            }
           }
         `}
       </style>

--- a/src/components/CharacterImageView.tsx
+++ b/src/components/CharacterImageView.tsx
@@ -193,6 +193,7 @@ function extractDef(data: unknown): string {
 export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: CharacterImageViewProps) {
   const navigate = useNavigate();
   const [segments, setSegments] = useState<TermSegment[]>([]);
+  const [segmentsLoading, setSegmentsLoading] = useState(true);
   const [shareSupported] = useState(() => typeof navigator !== 'undefined' && !!navigator.share);
   const [font, setFont] = useState(getStoredFont);
   const [hollowMode, setHollowMode] = useState(true);
@@ -209,6 +210,8 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
 
   useEffect(() => {
     let cancelled = false;
+    setSegmentsLoading(true);
+    setSegments([]);
 
     async function loadSegments() {
       const results: TermSegment[] = [];
@@ -224,7 +227,10 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
           results.push({ part, href: null, def: '' });
         }
       }
-      if (!cancelled) setSegments(results);
+      if (!cancelled) {
+        setSegments(results);
+        setSegmentsLoading(false);
+      }
     }
 
     loadSegments();
@@ -501,52 +507,68 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
           }}
         >
           <tbody>
-            {segments.map((segment) => (
-              <tr key={segment.part}>
-                <td style={{ verticalAlign: 'top', padding: 4 }}>
-                  <div className="charimg-practice-box" style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}>
-                    <img
-                      className="charimg-glyph charimg-glyph-segment"
-                      src={charImgUrl(segment.part, font)}
-                      alt={segment.part}
-                      style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}
-                    />
-                    <canvas
-                      className="charimg-draw-canvas"
-                      ref={registerCanvas(`segment:${segment.part}`, SEGMENT_IMAGE_SIZE, SEGMENT_IMAGE_SIZE)}
-                      onPointerDown={(event) => handleCanvasPointerDown(`segment:${segment.part}`, event)}
-                      onPointerMove={(event) => handleCanvasPointerMove(`segment:${segment.part}`, event)}
-                      onPointerUp={(event) => finishDrawing(`segment:${segment.part}`, event)}
-                      onPointerLeave={(event) => finishDrawing(`segment:${segment.part}`, event)}
-                      onPointerCancel={(event) => finishDrawing(`segment:${segment.part}`, event)}
-                    />
-                  </div>
-                </td>
+            {segmentsLoading ? (
+              <tr>
                 <td
+                  colSpan={2}
                   style={{
-                    verticalAlign: 'top',
-                    padding: '16px 12px',
-                    color: '#006',
-                    textAlign: 'left',
-                    lineHeight: 1.6,
+                    padding: '16px 24px',
+                    textAlign: 'center',
+                    color: '#666',
                     fontSize: '1.05em',
-                    wordBreak: 'break-word',
                   }}
                 >
-                  {segment.href ? (
-                    <a
-                      href={segment.href}
-                      style={{ color: '#006' }}
-                      onClick={(e) => handleTermClick(e, segment.href!)}
-                    >
-                      {segment.def || segment.part}
-                    </a>
-                  ) : (
-                    <span style={{ color: '#999' }}>{segment.part}</span>
-                  )}
+                  載入中...
                 </td>
               </tr>
-            ))}
+            ) : (
+              segments.map((segment) => (
+                <tr key={segment.part}>
+                  <td style={{ verticalAlign: 'top', padding: 4 }}>
+                    <div className="charimg-practice-box" style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}>
+                      <img
+                        className="charimg-glyph charimg-glyph-segment"
+                        src={charImgUrl(segment.part, font)}
+                        alt={segment.part}
+                        style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}
+                      />
+                      <canvas
+                        className="charimg-draw-canvas"
+                        ref={registerCanvas(`segment:${segment.part}`, SEGMENT_IMAGE_SIZE, SEGMENT_IMAGE_SIZE)}
+                        onPointerDown={(event) => handleCanvasPointerDown(`segment:${segment.part}`, event)}
+                        onPointerMove={(event) => handleCanvasPointerMove(`segment:${segment.part}`, event)}
+                        onPointerUp={(event) => finishDrawing(`segment:${segment.part}`, event)}
+                        onPointerLeave={(event) => finishDrawing(`segment:${segment.part}`, event)}
+                        onPointerCancel={(event) => finishDrawing(`segment:${segment.part}`, event)}
+                      />
+                    </div>
+                  </td>
+                  <td
+                    style={{
+                      verticalAlign: 'top',
+                      padding: '16px 12px',
+                      color: '#006',
+                      textAlign: 'left',
+                      lineHeight: 1.6,
+                      fontSize: '1.05em',
+                      wordBreak: 'break-word',
+                    }}
+                  >
+                    {segment.href ? (
+                      <a
+                        href={segment.href}
+                        style={{ color: '#006' }}
+                        onClick={(e) => handleTermClick(e, segment.href!)}
+                      >
+                        {segment.def || segment.part}
+                      </a>
+                    ) : (
+                      <span style={{ color: '#999' }}>{segment.part}</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </center>

--- a/src/components/CharacterImageView.tsx
+++ b/src/components/CharacterImageView.tsx
@@ -122,7 +122,7 @@ function setDrawingStyle(
   context.setTransform(ratio, 0, 0, ratio, 0, 0);
   context.lineCap = 'round';
   context.lineJoin = 'round';
-  context.lineWidth = 3;
+  context.lineWidth = 3.6;
   context.strokeStyle = 'rgba(27, 56, 89, 0.85)';
   context.fillStyle = 'rgba(27, 56, 89, 0.85)';
 }
@@ -374,7 +374,7 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
             cursor: crosshair;
           }
 
-          .charimg-result.charimg-hollow img.charimg-glyph {
+          .charimg-result.charimg-hollow img.charimg-glyph-segment {
             filter: invert(100%) grayscale(100%);
             opacity: .32;
           }
@@ -395,7 +395,7 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
           style={{ width: mainImageSize, height: mainImageSize }}
         >
           <img
-            className="charimg-glyph"
+            className="charimg-glyph charimg-glyph-main"
             src={charImgUrl(queryWord, font)}
             alt={queryWord}
             style={{ width: mainImageSize, height: mainImageSize }}
@@ -457,7 +457,7 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
               checked={hollowMode}
               onChange={(event) => setHollowMode(event.target.checked)}
             />
-            鏤空字模式
+            鏤空描寫模式
           </label>
         </div>
 
@@ -478,7 +478,7 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
                 <td style={{ verticalAlign: 'top', padding: 4 }}>
                   <div className="charimg-practice-box" style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}>
                     <img
-                      className="charimg-glyph"
+                      className="charimg-glyph charimg-glyph-segment"
                       src={charImgUrl(segment.part, font)}
                       alt={segment.part}
                       style={{ width: SEGMENT_IMAGE_SIZE, height: SEGMENT_IMAGE_SIZE }}

--- a/src/components/CharacterImageView.tsx
+++ b/src/components/CharacterImageView.tsx
@@ -382,6 +382,10 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
 
           .charimg-result.charimg-hollow img.charimg-glyph-segment {
             filter: invert(100%) grayscale(100%);
+            -webkit-filter: invert(100%) grayscale(100%);
+            -moz-filter: invert(100%) grayscale(100%);
+            -ms-filter: invert(100%) grayscale(100%);
+            -o-filter: invert(100%) grayscale(100%);
             opacity: .32;
           }
 
@@ -485,7 +489,7 @@ export function CharacterImageView({ queryWord, terms, lang, langTokenPrefix }: 
           >
             清除描寫
           </button>
-          <label style={{ marginBottom: 0, display: 'inline-flex', gap: 4, alignItems: 'center' }}>
+          <label style={{ marginBottom: 0, display: 'inline-flex', gap: 4, alignItems: 'center', fontWeight: 'normal' }}>
             <input
               type="checkbox"
               checked={hollowMode}

--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -114,7 +114,30 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 		}
 
 		@media print {
-			.query-box { display: none; }
+			.query-box,
+			.nav-bg,
+			.navbar-fixed-top {
+				display: none !important;
+			}
+
+			body {
+				padding-top: 0 !important;
+			}
+
+			#main-content {
+				margin-left: 0 !important;
+				margin-top: 0 !important;
+			}
+
+			/* 字圖列印只保留字形，隱藏詞意說明欄 */
+			.charimg-result .moetext td:nth-child(2) {
+				display: none !important;
+			}
+
+			.charimg-result .moetext {
+				max-width: 100% !important;
+				margin: 0 auto;
+			}
 		}
 
 			@media only screen and (max-width: 767px) {


### PR DESCRIPTION
# PR 說明：404 字圖頁新增鏤空列印與描寫練習

## 背景與目的

使用者回饋在教學寫字情境中，若可直接列印「鏤空字」讓學習者描寫，學習效果會更好。  
本次調整以最小侵入方式實作前端切換與列印優化，保留既有使用體驗。

## 主要修訂內容

### 1) 404 字圖頁新增「鏤空字模式」切換

- 檔案：`src/components/CharacterImageView.tsx`
- 新增 checkbox（預設開啟）控制鏤空字樣式
- 鏤空字模式套用 CSS：
  - `filter: invert(100%) grayscale(100%);`
  - `opacity: .32;`
- 鏤空字模式搭配可繪圖的canvases，讓使用者可以直接用滑鼠或觸控來描字學習  
- 使用者可勾選取消鏤空字，回到原本的紅底白字


### 2) 404 字圖頁新增列印與清除操作

- 檔案：`src/components/CharacterImageView.tsx`
- 新增按鈕：
  - `列印字卡`：觸發 `window.print()`
  - `清除描寫`：清空所有描寫畫布筆跡
- 既有分享按鈕與字體切換功能維持可用

### 3) 404 字圖頁新增透明描寫畫布（支援滑鼠/觸控）

- 檔案：`src/components/CharacterImageView.tsx`
- 在主字圖與每個分段字圖上方新增透明 `canvas`
- 畫布尺寸與字圖對齊，可直接描寫練習
- 以 Pointer Events 實作，支援：
  - 滑鼠
  - 觸控裝置
  - 連續書寫與離開/取消事件收尾
- 考量高 DPI 裝置，依 `devicePixelRatio` 初始化畫布，避免筆跡模糊

### 4) 列印樣式優化（隱藏不必要內容）

- 檔案：`src/components/InlineStyles.tsx`
- 於 `@media print` 新增規則，列印時：
  - 隱藏側欄與導覽：`.query-box`、`.nav-bg`、`.navbar-fixed-top`
  - 移除內容區列印留白：`body padding-top` 與 `#main-content margin`
  - 在字圖頁隱藏詞意欄位：`.charimg-result .moetext td:nth-child(2)`
  - 保留並置中字圖表格，聚焦描字用途
- 一般瀏覽情境不受影響（僅限 `@media print`）

## 驗證結果

- `src/components/CharacterImageView.tsx` ESLint 通過
- `src/components/InlineStyles.tsx` ESLint 通過
- 本次變更未新增 linter 錯誤

## 管理員檢閱重點

1. `404` 字圖頁 UI：控制列（分享/列印/清除/鏤空切換）是否符合預期  
2. 滑鼠與手機觸控描寫體驗是否順暢、是否能正確清除  
3. 列印預覽是否僅保留字圖區塊，不顯示側欄與詞意欄  
4. 鏤空字模式開關在列印輸出是否如預期生效

### 相關議題

close #92 


### 效果截圖

<img width="1377" height="731" alt="萌典好讚" src="https://github.com/user-attachments/assets/192ef599-72d8-4c74-ad84-63917cf2c70b" />

<img width="991" height="651" alt="列印版" src="https://github.com/user-attachments/assets/6cb73254-45a0-45a8-89bf-dfcda5f29a32" />


