### PR TITLE
改善 iOS 長按選字與滑動換頁判斷

### DIFF
--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -581,6 +581,32 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 			margin: .4em 0 0 20px;
 			padding-top: 1em;
 		}
+
+		/* ===== iOS 長按選字 vs 短按查字 =====
+		   內容中每個字都是可點的 <a>（短按＝查字）。iOS 預設長按 <a> 會跳出
+		   連結選單（開啟／拷貝連結）而非選取文字，導致無法選字複製。
+		   這裡關閉內容連結的 touch-callout 並允許文字選取：
+		   - 短按：照常觸發 click → 查字
+		   - 長按：可選取文字並複製 */
+		.result .def,
+		.result .definition,
+		.result .example,
+		.result .mandarin,
+		.result blockquote {
+			-webkit-user-select: text;
+			user-select: text;
+		}
+		.result .def a,
+		.result .definition a,
+		.result .example a,
+		.result .mandarin a,
+		.result blockquote a {
+			-webkit-touch-callout: none;
+			-webkit-user-drag: none;
+			user-drag: none;
+			-webkit-user-select: text;
+			user-select: text;
+		}
 		`
 			}}
 		/>

--- a/src/hooks/useSwipeNavigation.ts
+++ b/src/hooks/useSwipeNavigation.ts
@@ -1,12 +1,33 @@
 /**
  * 滑動手勢導航 hook
- * 偵測水平滑動，往右滑回到上一頁，往左滑前往下一頁
+ * 偵測「快速水平甩動」，往右滑回到上一頁，往左滑前往下一頁。
+ *
+ * 為了避免在 iOS 上「長按選取文字再拖曳」被誤判成換頁，這裡用多重條件
+ * 來區分「滑動換頁」與「選字拖曳」：
+ *  - 選取中（touchend 時仍有文字被選取）一律不換頁
+ *  - 多指手勢（縮放等）不算滑動
+ *  - 在可編輯欄位（input / textarea / contenteditable）上不觸發
+ *  - 換頁滑動必須是「快速一甩」：時間夠短且速度夠快，慢慢拖曳不算
  */
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const SWIPE_THRESHOLD = 50;       // 最小滑動距離（px）
+const SWIPE_THRESHOLD = 60;       // 最小滑動距離（px）
 const MAX_VERTICAL_RATIO = 0.3;   // 最大允許垂直偏移比例
+const MAX_DURATION = 500;         // 最長手勢時間（ms）；超過視為慢速拖曳（多半在選字）
+const MIN_VELOCITY = 0.3;         // 最小水平速度（px/ms）；過慢視為選字而非甩動
+
+/** 此次觸控是否落在可編輯／可選取互動元素內 */
+function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target instanceof Element ? target.closest('input, textarea, [contenteditable=""], [contenteditable="true"]') : null;
+  return el != null;
+}
+
+/** 目前是否有非空的文字選取 */
+function hasActiveSelection(): boolean {
+  const selection = window.getSelection();
+  return selection != null && !selection.isCollapsed && selection.toString().trim().length > 0;
+}
 
 export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | null>) {
   const navigate = useNavigate();
@@ -17,9 +38,21 @@ export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | nul
     if (!el) return;
 
     const handleTouchStart = (e: TouchEvent) => {
+      // 多指手勢（縮放等）或落在可編輯元素上：不視為換頁滑動
+      if (e.touches.length > 1 || isEditableTarget(e.target)) {
+        touchStart.current = null;
+        return;
+      }
       const touch = e.touches[0];
       if (!touch) return;
       touchStart.current = { x: touch.clientX, y: touch.clientY, time: Date.now() };
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      // 中途出現第二指（縮放）：取消此次滑動判定
+      if (e.touches.length > 1) {
+        touchStart.current = null;
+      }
     };
 
     const handleTouchEnd = (e: TouchEvent) => {
@@ -30,13 +63,20 @@ export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | nul
       const touch = e.changedTouches[0];
       if (!touch) return;
 
+      // 使用者正在選取文字（想複製）：不換頁
+      if (hasActiveSelection()) return;
+
       const deltaX = touch.clientX - start.x;
       const deltaY = touch.clientY - start.y;
+      const duration = Date.now() - start.time;
 
       // 檢查是否為水平滑動：垂直偏移不可超過水平距離的 30%
       if (Math.abs(deltaY) > Math.abs(deltaX) * MAX_VERTICAL_RATIO) return;
       // 檢查滑動距離是否超過門檻
       if (Math.abs(deltaX) < SWIPE_THRESHOLD) return;
+      // 必須是「快速一甩」：時間夠短、速度夠快，過濾掉慢速選字拖曳
+      if (duration > MAX_DURATION) return;
+      if (Math.abs(deltaX) / duration < MIN_VELOCITY) return;
 
       if (deltaX > 0) {
         // 往右滑 → 上一頁
@@ -48,10 +88,12 @@ export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | nul
     };
 
     el.addEventListener('touchstart', handleTouchStart, { passive: true });
+    el.addEventListener('touchmove', handleTouchMove, { passive: true });
     el.addEventListener('touchend', handleTouchEnd, { passive: true });
 
     return () => {
       el.removeEventListener('touchstart', handleTouchStart);
+      el.removeEventListener('touchmove', handleTouchMove);
       el.removeEventListener('touchend', handleTouchEnd);
     };
   }, [elementRef, navigate]);

--- a/src/hooks/useSwipeNavigation.ts
+++ b/src/hooks/useSwipeNavigation.ts
@@ -1,9 +1,10 @@
 /**
  * 滑動手勢導航 hook
- * 偵測「快速水平甩動」，往右滑回到上一頁，往左滑前往下一頁。
+ * 偵測「從螢幕邊緣起手的快速水平甩動」，往右滑回到上一頁，往左滑前往下一頁。
  *
  * 為了避免在 iOS 上「長按選取文字再拖曳」被誤判成換頁，這裡用多重條件
  * 來區分「滑動換頁」與「選字拖曳」：
+ *  - 必須從螢幕左／右邊緣起手（內容中間的拖曳＝選字，完全不觸發換頁）
  *  - 選取中（touchend 時仍有文字被選取）一律不換頁
  *  - 多指手勢（縮放等）不算滑動
  *  - 在可編輯欄位（input / textarea / contenteditable）上不觸發
@@ -16,6 +17,7 @@ const SWIPE_THRESHOLD = 60;       // 最小滑動距離（px）
 const MAX_VERTICAL_RATIO = 0.3;   // 最大允許垂直偏移比例
 const MAX_DURATION = 500;         // 最長手勢時間（ms）；超過視為慢速拖曳（多半在選字）
 const MIN_VELOCITY = 0.3;         // 最小水平速度（px/ms）；過慢視為選字而非甩動
+const EDGE_ZONE = 60;             // 邊緣起手感應區寬度（px）：只有從左／右緣起手才換頁
 
 /** 此次觸控是否落在可編輯／可選取互動元素內 */
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -78,11 +80,14 @@ export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | nul
       if (duration > MAX_DURATION) return;
       if (Math.abs(deltaX) / duration < MIN_VELOCITY) return;
 
+      const viewportWidth = window.innerWidth;
       if (deltaX > 0) {
-        // 往右滑 → 上一頁
+        // 往右滑 → 上一頁：必須從「左邊緣」起手
+        if (start.x > EDGE_ZONE) return;
         navigate(-1);
       } else {
-        // 往左滑 → 下一頁
+        // 往左滑 → 下一頁：必須從「右邊緣」起手
+        if (start.x < viewportWidth - EDGE_ZONE) return;
         navigate(1);
       }
     };

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type KeyboardEvent, type MouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent, type TouchEvent as ReactTouchEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRadicalTooltip } from '../hooks/useRadicalTooltip';
 import { cleanTextForTTS, speakText } from '../utils/tts-utils';
@@ -68,6 +68,10 @@ interface DictionaryPageProps {
   lang: DictionaryLang;
 }
 
+const CONTENT_LOOKUP_LINK_SELECTOR = '.def a, .definition a, .example a, .mandarin a, .quote a, .link a, blockquote a';
+const LONG_PRESS_MIN_DURATION_MS = 320;
+const LONG_PRESS_SUPPRESS_CLICK_MS = 450;
+
 function groupDefinitions(definitions: Definition[]): Map<string, Definition[]> {
   const grouped = new Map<string, Definition[]>();
   for (const definition of definitions) {
@@ -112,6 +116,15 @@ function normalizeHref(rawHref: string): string | null {
   token = token.trim();
   if (!token) return null;
   return `/${token}`;
+}
+
+function hasActiveSelection(): boolean {
+  const selection = window.getSelection();
+  return selection != null && !selection.isCollapsed && selection.toString().trim().length > 0;
+}
+
+function isContentLookupAnchor(anchor: HTMLAnchorElement): boolean {
+  return anchor.matches(CONTENT_LOOKUP_LINK_SELECTOR);
 }
 
 function untag(input: string): string {
@@ -351,6 +364,8 @@ function RadicalGlyph({ char, lang }: { char: string; lang: DictionaryLang }) {
 
 export function DictionaryPage({ word, lang }: DictionaryPageProps) {
   const navigate = useNavigate();
+  const touchAnchorStartAtRef = useRef<number | null>(null);
+  const suppressAnchorClickUntilRef = useRef(0);
   const queryWord = useMemo(() => (word ?? '').trim(), [word]);
   const langTokenPrefix = getLangTokenPrefix(lang);
   const [state, setState] = useState<DictionaryState>({
@@ -474,6 +489,11 @@ export function DictionaryPage({ word, lang }: DictionaryPageProps) {
     if (!(target instanceof HTMLElement)) return;
     const anchor = target.closest('a');
     if (!anchor) return;
+    const isLookupAnchor = isContentLookupAnchor(anchor);
+    if (isLookupAnchor && (hasActiveSelection() || Date.now() < suppressAnchorClickUntilRef.current)) {
+      event.preventDefault();
+      return;
+    }
     const href = anchor.getAttribute('href');
     if (!href) return;
 
@@ -481,6 +501,30 @@ export function DictionaryPage({ word, lang }: DictionaryPageProps) {
     if (!normalized) return;
     event.preventDefault();
     navigate(normalized);
+  };
+
+  const onContentTouchStartCapture = (event: ReactTouchEvent<HTMLDivElement>): void => {
+    touchAnchorStartAtRef.current = null;
+    if (event.touches.length !== 1) return;
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const anchor = target.closest('a');
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    if (!isContentLookupAnchor(anchor)) return;
+    touchAnchorStartAtRef.current = Date.now();
+  };
+
+  const onContentTouchEndCapture = (): void => {
+    const startedAt = touchAnchorStartAtRef.current;
+    touchAnchorStartAtRef.current = null;
+    if (!startedAt) return;
+    if (Date.now() - startedAt >= LONG_PRESS_MIN_DURATION_MS) {
+      suppressAnchorClickUntilRef.current = Date.now() + LONG_PRESS_SUPPRESS_CLICK_MS;
+    }
+  };
+
+  const onContentTouchCancelCapture = (): void => {
+    touchAnchorStartAtRef.current = null;
   };
 
   if (state.error) {
@@ -519,7 +563,14 @@ export function DictionaryPage({ word, lang }: DictionaryPageProps) {
   const francais = translation.francais ?? entry.francais;
 
   return (
-    <div className="result" onClick={onContentClick} aria-busy={state.loading}>
+    <div
+      className="result"
+      onClick={onContentClick}
+      onTouchStartCapture={onContentTouchStartCapture}
+      onTouchEndCapture={onContentTouchEndCapture}
+      onTouchCancelCapture={onContentTouchCancelCapture}
+      aria-busy={state.loading}
+    >
       {/* 筆順動畫區域（同原 index.html #strokes 位於 .results 頂部） */}
       <StrokeAnimation title={title} visible={strokesVisible} lang={lang} />
 


### PR DESCRIPTION
## 摘要
- 將左右滑換頁限制為從螢幕邊緣起手，避免內容區選字拖曳被誤判成換頁。
- 改善 iOS 上長按字典內容連結時的選字行為，讓長按偏向選取文字、短按仍維持查字。
- 保留 `<a>` 標記，透過 TSX 觸控判斷與內聯樣式調整降低連結拖曳／誤觸導航。

## 檢查清單
- [x] 網頁近端測試
- [x] iOS 模擬器測試
- [x] Android 模擬器測試

Made with [Cursor](https://cursor.com)