### PR TITLE
fix: 長按選字涵蓋引文/連結，並修正滑動換頁冷啟動未綁定 (#116 後續)

### DIFF
--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -587,12 +587,15 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 		   連結選單（開啟／拷貝連結）而非選取文字，導致無法選字複製。
 		   這裡關閉內容連結的 touch-callout 並允許文字選取：
 		   - 短按：照常觸發 click → 查字
-		   - 長按：可選取文字並複製 */
+		   - 長按：可選取文字並複製
+		   注意：下列 class 必須與 DictionaryPage.tsx 的 CONTENT_LOOKUP_LINK_SELECTOR 保持一致，
+		   否則某些可查字的連結（如引文 .quote、連結 .link）長按時仍會跳出 iOS 原生選單。 */
 		.result .def,
 		.result .definition,
 		.result .example,
 		.result .mandarin,
-		.result blockquote {
+		.result .quote,
+		.result .link {
 			-webkit-user-select: text;
 			user-select: text;
 		}
@@ -600,7 +603,8 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 		.result .definition a,
 		.result .example a,
 		.result .mandarin a,
-		.result blockquote a {
+		.result .quote a,
+		.result .link a {
 			-webkit-touch-callout: none;
 			-webkit-user-drag: none;
 			user-drag: none;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@
  * 根據 layout 類型切換不同的頁面結構
  */
 
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { NavbarAbout } from './navbar-about';
 import { NavbarNormal } from './navbar-normal';
 import { Sidebar } from './sidebar';
@@ -29,8 +29,7 @@ interface LayoutProps {
 export function Layout({ layout, children, currentLang, r2Endpoint }: LayoutProps) {
 	const [criticalCssReady, setCriticalCssReady] = useState(false);
 	const [inlineStylesReady, setInlineStylesReady] = useState(false);
-	const mainRef = useRef<HTMLElement | null>(null);
-	useSwipeNavigation(mainRef);
+	const swipeRef = useSwipeNavigation();
 
 	useEffect(() => {
 		if (r2Endpoint) {
@@ -54,7 +53,7 @@ export function Layout({ layout, children, currentLang, r2Endpoint }: LayoutProp
 			{layout === 'about' ? (
 				<div className="app-shell">
 					<NavbarAbout r2Endpoint={r2Endpoint} />
-					<main id="main-content" className="about-layout" ref={mainRef}>
+					<main id="main-content" className="about-layout" ref={swipeRef}>
 						{children}
 					</main>
 				</div>
@@ -63,7 +62,7 @@ export function Layout({ layout, children, currentLang, r2Endpoint }: LayoutProp
 					<NavbarNormal currentLang={currentLang} />
 					<Sidebar currentLang={currentLang} />
 					<UserPref />
-					<main id="main-content" ref={mainRef}>
+					<main id="main-content" ref={swipeRef}>
 						{children}
 					</main>
 				</div>

--- a/src/hooks/useSwipeNavigation.ts
+++ b/src/hooks/useSwipeNavigation.ts
@@ -9,8 +9,13 @@
  *  - 多指手勢（縮放等）不算滑動
  *  - 在可編輯欄位（input / textarea / contenteditable）上不觸發
  *  - 換頁滑動必須是「快速一甩」：時間夠短且速度夠快，慢慢拖曳不算
+ *
+ * 此 hook 回傳一個 callback ref，請直接掛在要監聽的元素上（例如 <main ref={swipeRef}>）。
+ * 用 callback ref 而非 useEffect + RefObject，是為了在元素「掛載當下」就立即綁定 listener；
+ * 否則冷啟動時 <main> 還沒 render（Layout 仍在 loading 分支），effect 先跑一次拿到 null，
+ * 之後 <main> 掛上時 deps 沒變、effect 不會重跑，導致要先點一次才會生效。
  */
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const SWIPE_THRESHOLD = 60;       // 最小滑動距離（px）
@@ -31,12 +36,23 @@ function hasActiveSelection(): boolean {
   return selection != null && !selection.isCollapsed && selection.toString().trim().length > 0;
 }
 
-export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | null>) {
+export function useSwipeNavigation(): (el: HTMLElement | null) => void {
   const navigate = useNavigate();
-  const touchStart = useRef<{ x: number; y: number; time: number } | null>(null);
-
+  // 用 ref 保存最新的 navigate，讓 listener 不必在每次換頁（navigate 身分改變）時重綁。
+  const navigateRef = useRef(navigate);
   useEffect(() => {
-    const el = elementRef.current;
+    navigateRef.current = navigate;
+  }, [navigate]);
+
+  const touchStart = useRef<{ x: number; y: number; time: number } | null>(null);
+  const detach = useRef<(() => void) | null>(null);
+
+  return useCallback((el: HTMLElement | null) => {
+    // 先卸除前一個元素上的 listener（元素替換或卸載時）
+    if (detach.current) {
+      detach.current();
+      detach.current = null;
+    }
     if (!el) return;
 
     const handleTouchStart = (e: TouchEvent) => {
@@ -84,11 +100,11 @@ export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | nul
       if (deltaX > 0) {
         // 往右滑 → 上一頁：必須從「左邊緣」起手
         if (start.x > EDGE_ZONE) return;
-        navigate(-1);
+        navigateRef.current(-1);
       } else {
         // 往左滑 → 下一頁：必須從「右邊緣」起手
         if (start.x < viewportWidth - EDGE_ZONE) return;
-        navigate(1);
+        navigateRef.current(1);
       }
     };
 
@@ -96,10 +112,10 @@ export function useSwipeNavigation(elementRef: React.RefObject<HTMLElement | nul
     el.addEventListener('touchmove', handleTouchMove, { passive: true });
     el.addEventListener('touchend', handleTouchEnd, { passive: true });
 
-    return () => {
+    detach.current = () => {
       el.removeEventListener('touchstart', handleTouchStart);
       el.removeEventListener('touchmove', handleTouchMove);
       el.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [elementRef, navigate]);
+  }, []);
 }

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -68,7 +68,8 @@ interface DictionaryPageProps {
   lang: DictionaryLang;
 }
 
-const CONTENT_LOOKUP_LINK_SELECTOR = '.def a, .definition a, .example a, .mandarin a, .quote a, .link a, blockquote a';
+// 內容中「可查字」的逐字連結。必須與 InlineStyles.tsx 的長按選字 CSS 選擇器保持一致。
+const CONTENT_LOOKUP_LINK_SELECTOR = '.def a, .definition a, .example a, .mandarin a, .quote a, .link a';
 const LONG_PRESS_MIN_DURATION_MS = 320;
 const LONG_PRESS_SUPPRESS_CLICK_MS = 450;
 


### PR DESCRIPTION
近端測試 PR #118/#119（issue #116 滑動換頁 + 長按選字）時，發現兩個小問題，這裡一起修正。核心功能本身都正常。

## 修正內容

### 1. iOS 長按選字漏掉「引文 / 連結」裡的字
`InlineStyles.tsx` 關閉 `-webkit-touch-callout` / 開 `user-select: text` 的 CSS，以及 `DictionaryPage.tsx` 的 `CONTENT_LOOKUP_LINK_SELECTOR`，原本只涵蓋 `.def / .definition / .example / .mandarin`，**漏掉了 `.quote a` 與 `.link a`**；而且兩處選擇器都用到 `blockquote`，但實際 DOM 並不存在 `<blockquote>`（引文是 `<div class="quote">`、連結是 `<div class="link">`）。

結果：iOS 長按古籍引文、連結裡的字仍會跳出原生選單、選不到字——而引文正是使用者最想複製的內容。

修正：兩處選擇器補上 `.quote a`、`.link a`，移除無效的 `blockquote`，並讓 CSS 與 JS 選擇器互相對齊（加註解交叉引用）。

### 2. 滑動換頁在冷啟動第一頁未綁定 listener
`useSwipeNavigation` 原本用 `useEffect` + `RefObject`，但 `Layout` 在 `criticalCssReady && inlineStylesReady` 之前的 loading 分支不 render `<main>`，effect 先跑一次拿到 `null`、之後 `<main>` 掛上時 deps 沒變不會重跑 —— 導致冷啟動第一頁要先點一次（任何 in-app 導航）滑動才生效。

修正：改成回傳 **callback ref**，在 `<main>` 掛載當下立即綁定 listener（`Layout` 改用 `ref={swipeRef}`），並用 `navigateRef` 保存最新 `navigate` 避免每次換頁重綁。手勢判定邏輯完全不變。

## 測試
- `tsgo -b --noEmit` / `eslint` 通過。
- 瀏覽器（合成 touch 事件）：滑動換頁、長按選字/短按查字、各反向情境皆正常；冷啟動第一頁直接滑動現在即可換頁；`.quote a` 的 `user-select` 由 `auto` 變為 `text`。
- Android 15 模擬器：返回鍵/手勢有上一頁時正常回上一頁、不退出 App（以 trusted input 實測）。

## 備註
Android 在 history 最底層按返回會「停住、不退出 App」維持原設計（刻意避免誤觸退出）；如需更貼近 Android 慣例可後續再以 `moveTaskToBack` / `setEnabled(canGoBack())` 調整，本 PR 不動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)