### PR TITLE
以最小更動，修復ToolTip殘留問題，work on #121

### DIFF
--- a/src/hooks/useRadicalTooltip.ts
+++ b/src/hooks/useRadicalTooltip.ts
@@ -305,6 +305,11 @@ export function useRadicalTooltip(): void {
     let currentId = '';
     let currentAnchor: HTMLAnchorElement | null = null;
     const cache = new Map<string, string>();
+    // 換頁剛收掉 tooltip 後，短時間內阻擋「新內容出現在游標下方時瀏覽器自動補發的
+    // mouseover」把 tooltip 重新打開（否則會在左上角閃現一下）。
+    const SUPPRESS_REOPEN_MS = 300;
+    let suppressShow = false;
+    let suppressTimer: number | null = null;
 
     const clearShowTimer = () => {
       if (showTimer != null) {
@@ -423,7 +428,23 @@ export function useRadicalTooltip(): void {
       currentAnchor = null;
     };
 
+    // 由 DictionaryPage 在「不換頁路由」跳轉前派發 moedict:dismiss-tooltip 事件呼叫：
+    // 立即收掉殘留 tooltip，並在 SUPPRESS_REOPEN_MS 內阻擋重開——換頁後新內容會出現在
+    // 游標下方，瀏覽器會自動補一個 mouseover，若不擋會立刻把 tooltip 重新打開（左上角閃現）。
+    const dismissTooltip = () => {
+      clearShowTimer();
+      clearHideTimer();
+      hideTooltip();
+      suppressShow = true;
+      if (suppressTimer != null) window.clearTimeout(suppressTimer);
+      suppressTimer = window.setTimeout(() => {
+        suppressShow = false;
+        suppressTimer = null;
+      }, SUPPRESS_REOPEN_MS);
+    };
+
     const onMouseOver = (event: MouseEvent) => {
+      if (suppressShow) return;
       const target = resolveTooltipTarget(event.target);
       if (!target) return;
 
@@ -461,8 +482,8 @@ export function useRadicalTooltip(): void {
 
     document.addEventListener('mouseover', onMouseOver);
     document.addEventListener('mouseout', onMouseOut);
-    // 換頁（不換頁路由）時由 DictionaryPage 派發此事件，重用既有關閉函式收掉殘留 tooltip
-    document.addEventListener('moedict:dismiss-tooltip', hideTooltip);
+    // 換頁（不換頁路由）時由 DictionaryPage 派發此事件，收掉殘留 tooltip 並短暫阻擋重開
+    document.addEventListener('moedict:dismiss-tooltip', dismissTooltip);
     window.addEventListener('scroll', refreshPosition, true);
     window.addEventListener('resize', refreshPosition);
 
@@ -471,7 +492,8 @@ export function useRadicalTooltip(): void {
       clearHideTimer();
       document.removeEventListener('mouseover', onMouseOver);
       document.removeEventListener('mouseout', onMouseOut);
-      document.removeEventListener('moedict:dismiss-tooltip', hideTooltip);
+      document.removeEventListener('moedict:dismiss-tooltip', dismissTooltip);
+      if (suppressTimer != null) window.clearTimeout(suppressTimer);
       window.removeEventListener('scroll', refreshPosition, true);
       window.removeEventListener('resize', refreshPosition);
       if (tooltipEl) {

--- a/src/hooks/useRadicalTooltip.ts
+++ b/src/hooks/useRadicalTooltip.ts
@@ -461,6 +461,8 @@ export function useRadicalTooltip(): void {
 
     document.addEventListener('mouseover', onMouseOver);
     document.addEventListener('mouseout', onMouseOut);
+    // 換頁（不換頁路由）時由 DictionaryPage 派發此事件，重用既有關閉函式收掉殘留 tooltip
+    document.addEventListener('moedict:dismiss-tooltip', hideTooltip);
     window.addEventListener('scroll', refreshPosition, true);
     window.addEventListener('resize', refreshPosition);
 
@@ -469,6 +471,7 @@ export function useRadicalTooltip(): void {
       clearHideTimer();
       document.removeEventListener('mouseover', onMouseOver);
       document.removeEventListener('mouseout', onMouseOut);
+      document.removeEventListener('moedict:dismiss-tooltip', hideTooltip);
       window.removeEventListener('scroll', refreshPosition, true);
       window.removeEventListener('resize', refreshPosition);
       if (tooltipEl) {

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -501,7 +501,19 @@ export function DictionaryPage({ word, lang }: DictionaryPageProps) {
     const normalized = normalizeHref(href);
     if (!normalized) return;
     event.preventDefault();
-    navigate(normalized);
+    // 換頁前先用既有的 mouseout 關閉函式收掉殘留的 tooltip，待 300ms 後跳轉。
+    document.dispatchEvent(new Event('moedict:dismiss-tooltip'));
+    // console.debug('[tooltip-entry] dispatched dismiss-tooltip event');
+    let navigated = false;
+    let fallbackTimer = 0;
+    const goToEntry = () => {
+      if (navigated) return;
+      navigated = true;
+      window.clearTimeout(fallbackTimer);
+      // console.debug('[tooltip-entry] navigating to', normalized);
+      navigate(normalized);
+    };
+    fallbackTimer = window.setTimeout(goToEntry, 300);
   };
 
   const onContentTouchStartCapture = (event: ReactTouchEvent<HTMLDivElement>): void => {

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -501,19 +501,10 @@ export function DictionaryPage({ word, lang }: DictionaryPageProps) {
     const normalized = normalizeHref(href);
     if (!normalized) return;
     event.preventDefault();
-    // 換頁前先用既有的 mouseout 關閉函式收掉殘留的 tooltip，待 300ms 後跳轉。
+    // 換頁前先收掉殘留的 tooltip：hideTooltip 為同步（直接設 display:none），
+    // 派發事件當下即生效，因此可立即跳轉、不需延遲。
     document.dispatchEvent(new Event('moedict:dismiss-tooltip'));
-    // console.debug('[tooltip-entry] dispatched dismiss-tooltip event');
-    let navigated = false;
-    let fallbackTimer = 0;
-    const goToEntry = () => {
-      if (navigated) return;
-      navigated = true;
-      window.clearTimeout(fallbackTimer);
-      // console.debug('[tooltip-entry] navigating to', normalized);
-      navigate(normalized);
-    };
-    fallbackTimer = window.setTimeout(goToEntry, 300);
+    navigate(normalized);
   };
 
   const onContentTouchStartCapture = (event: ReactTouchEvent<HTMLDivElement>): void => {


### PR DESCRIPTION
@audreyt 
# 修復查詢頁換頁後 tooltip 殘留

## 摘要

這次更動修復字典查詢頁在點擊內文連結切換詞條時，既有 tooltip 可能殘留在畫面上的問題。現在 `DictionaryPage` 會在導頁前派發 `moedict:dismiss-tooltip` 事件，並由 `useRadicalTooltip` 監聽後重用原本的關閉流程收掉 tooltip，避免 tooltip 跟著新頁面內容一起留在畫面上。


note: 為了修理並確保Tooltip先收掉才跳頁，加入了300ms的時間延遲


close #121

## 驗證

- 點擊字典頁內文連結切換詞條時，tooltip 會先被關閉再導向新詞條。
- 換頁後不應再看到上一個詞條觸發的 tooltip 殘留。
