### PR TITLE
fix: /moetris 與 /moetris/ 302 重導向至 dodo 子網域

### DIFF
--- a/tests/unit/worker-dispatch.test.ts
+++ b/tests/unit/worker-dispatch.test.ts
@@ -191,6 +191,20 @@ describe('dispatch — /robots.txt', () => {
   });
 });
 
+describe('dispatch — /moetris', () => {
+  it('302-redirects /moetris to dodo.moedict.tw', async () => {
+    const res = await dispatch(req('/moetris'), makeEnv());
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://dodo.moedict.tw/moetris.html');
+  });
+
+  it('302-redirects /moetris/ (trailing slash) to dodo.moedict.tw', async () => {
+    const res = await dispatch(req('/moetris/'), makeEnv());
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://dodo.moedict.tw/moetris.html');
+  });
+});
+
 describe('dispatch — /images/Download_on_the_App_Store_Badge_HK_TW_135x40.png', () => {
   it('serves the PNG from ASSETS R2 with caching + etag', async () => {
     const env = makeEnv({

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -244,6 +244,17 @@ export async function dispatch(request: Request, env: Env): Promise<Response> {
       return new Response(body, { status: 200, headers });
     }
 
+    // 特殊路由：moetris 方塊遊戲已搬遷至 dodo 子網域，302 重導向（#123）
+    if (url.pathname === '/moetris' || url.pathname === '/moetris/') {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          'Location': 'https://dodo.moedict.tw/moetris.html',
+          'Cache-Control': 'public, max-age=3600',
+        },
+      });
+    }
+
     // lookup API（台語羅馬拼音索引 / 舊站 trs 相容）
     const lookupResponse = await handleLookupAPI(request, url, env);
     if (lookupResponse) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,7 @@
 	"compatibility_date": "2025-11-05",
 	"assets": {
 		"not_found_handling": "single-page-application",
-		"run_worker_first": ["/robots.txt", "/api/*", "/lookup/trs/*", "/*.png", "/*.json", "/manifest.appcache", "/translation-data/cfdict.txt", "/translation-data/cfdict.xml", "!/manifest.json"]
+		"run_worker_first": ["/robots.txt", "/moetris", "/moetris/", "/api/*", "/lookup/trs/*", "/*.png", "/*.json", "/manifest.appcache", "/translation-data/cfdict.txt", "/translation-data/cfdict.xml", "!/manifest.json"]
 	},
 	"observability": {
 		"enabled": true


### PR DESCRIPTION
## 摘要

修復特殊路由 `/moetris`，close #123。

moetris 方塊遊戲已搬遷至 https://dodo.moedict.tw/moetris.html
，舊路由 `https://www.moedict.tw/moetris/` 與 `https://www.moedict.tw/moetris` 在新版網站失效。

## 改動內容

- **`worker/index.ts`**：在 dispatch 加上特殊路由，`/moetris` 與 `/moetris/` 回傳 302 重導向至 `https://dodo.moedict.tw/moetris.html`（含 1 小時快取）。
- **`wrangler.jsonc`**：依 issue 提示，在 `run_worker_first` 加入 `/moetris` 與 `/moetris/`，避免被 SPA 靜態資產處理搶先攔截。
- **`tests/unit/worker-dispatch.test.ts`**：新增測試驗證帶/不帶尾斜線都正確 302 到 dodo 網址。

## 驗證

- `bun run test:unit` → 858 passed
- `bun run typecheck` → 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)