### PR TITLE
feat: render per-heteronym xrefs from ID-aware sidecar

### DIFF
--- a/src/api/handleDictionaryAPI.ts
+++ b/src/api/handleDictionaryAPI.ts
@@ -30,10 +30,15 @@ interface DictionaryEntry {
 interface DictionaryAPIResponse {
   [key: string]: unknown;
   xrefs?: Array<{ lang: DictionaryLang; words: string[] }>;
+  xrefsByHeteronym?: Array<{ lang: DictionaryLang; byId: Record<string, string[]> }>;
 }
 
 interface XRefData {
   [targetLang: string]: Record<string, string | string[]>;
+}
+
+interface XRefByIdData {
+  [targetLang: string]: Record<string, Record<string, string[]>>;
 }
 
 interface ConvertedDictionaryData {
@@ -448,6 +453,7 @@ export async function lookupDictionaryEntry(
   const entry = bucketResult.data;
   const processedEntry = processDictionaryEntry(entry, lang);
   processedEntry.xrefs = await getCrossReferences(text, lang, env);
+  processedEntry.xrefsByHeteronym = await getCrossReferencesById(text, lang, env);
   return processedEntry;
 }
 
@@ -772,6 +778,36 @@ async function getCrossReferences(
             .filter(Boolean);
       if (wordList.length > 0 && isDictionaryLang(targetLang)) {
         result.push({ lang: targetLang, words: wordList });
+      }
+    }
+
+    return result;
+  } catch {
+    return [];
+  }
+}
+
+async function getCrossReferencesById(
+  text: string,
+  lang: DictionaryLang,
+  env: DictionaryEnv,
+): Promise<Array<{ lang: DictionaryLang; byId: Record<string, string[]> }>> {
+  try {
+    const xrefPath = `${lang}/xref-by-id.json`;
+    const xrefObject = await env.DICTIONARY.get(xrefPath);
+    if (!xrefObject) {
+      return [];
+    }
+
+    const xrefData = await xrefObject.text();
+    const xref = JSON.parse(xrefData) as XRefByIdData;
+    const result: Array<{ lang: DictionaryLang; byId: Record<string, string[]> }> = [];
+
+    for (const [targetLang, byTitle] of Object.entries(xref)) {
+      const idMap = byTitle[text];
+      if (!idMap) continue;
+      if (isDictionaryLang(targetLang)) {
+        result.push({ lang: targetLang, byId: idMap });
       }
     }
 

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -50,6 +50,7 @@ interface DictionaryAPIResponse {
   Deutsch?: string | string[];
   francais?: string | string[];
   xrefs?: Array<{ lang: DictionaryLang; words: string[] }>;
+  xrefsByHeteronym?: Array<{ lang: DictionaryLang; byId: Record<string, string[]> }>;
 }
 
 interface DictionaryErrorResponse {
@@ -592,6 +593,15 @@ export function DictionaryPage({ word, lang, idx: targetDefIdx }: DictionaryPage
   const deutsch = translation.Deutsch ?? entry.Deutsch;
   const francais = translation.francais ?? entry.francais;
 
+  // Build a per-heteronym-ID xref lookup from the ID-aware sidecar data.
+  // Only the current entry's language is relevant here; xrefsByHeteronym
+  // maps each target language to { heteronymId: [words] }.
+  const xrefsByHeteronymId = entry.xrefsByHeteronym ?? [];
+  const xrefLangsWithById = new Set(xrefsByHeteronymId.map((x) => x.lang));
+  // Flat xrefs for languages that have ID-aware data are rendered per-heteronym
+  // inside each heteronym block; the rest remain at the bottom.
+  const flatXrefs = (entry.xrefs ?? []).filter((x) => !xrefLangsWithById.has(x.lang));
+
   return (
     <div
       className="result"
@@ -892,6 +902,40 @@ export function DictionaryPage({ word, lang, idx: targetDefIdx }: DictionaryPage
                 </span>
               </div>
             )}
+            {xrefsByHeteronymId.length > 0 && heteronym.id && (() => {
+              const xrefLinks: React.ReactNode[] = [];
+              for (const xref of xrefsByHeteronymId) {
+                const words = xref.byId[heteronym.id];
+                if (!words || words.length === 0) continue;
+                xrefLinks.push(
+                  <div key={`xref-by-id-${xref.lang}-${heteronym.id}`} className="xref-line">
+                    <span className="xref part-of-speech">{getLangName(xref.lang)}</span>
+                    <span className="xref">
+                      {words.map((xrefWord, wIdx) => {
+                        const normalizedXrefWord = normalizeXrefWord(xrefWord);
+                        const to = `/${getLangTokenPrefix(xref.lang)}${normalizedXrefWord}`;
+                        return (
+                          <span key={`xref-by-id-${xref.lang}-${heteronym.id}-${wIdx}`}>
+                            {wIdx > 0 ? '、' : ''}
+                            <a
+                              href={to}
+                              data-radical-id={`entry:${to}`}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                navigate(to);
+                              }}
+                            >
+                              {normalizedXrefWord}
+                            </a>
+                          </span>
+                        );
+                      })}
+                    </span>
+                  </div>
+                );
+              }
+              return xrefLinks.length > 0 ? <div className="xrefs">{xrefLinks}</div> : null;
+            })()}
           </div>
         );
       })}
@@ -904,9 +948,9 @@ export function DictionaryPage({ word, lang, idx: targetDefIdx }: DictionaryPage
         </div>
       )}
 
-      {entry.xrefs && entry.xrefs.length > 0 && (
+      {flatXrefs.length > 0 && (
         <div className="xrefs">
-          {entry.xrefs.map((xref) => (
+          {flatXrefs.map((xref) => (
             <div key={xref.lang} className="xref-line">
               <span className="xref part-of-speech">{getLangName(xref.lang)}</span>
               <span className="xref">

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -88,7 +88,7 @@ export function collectDictionaryFixtures(): FixtureEntry[] {
   }
 
   for (const lang of ['a', 't', 'h', 'c'] as const) {
-    for (const name of ['index.json', 'xref.json']) {
+    for (const name of ['index.json', 'xref.json', 'xref-by-id.json']) {
       const key = `${lang}/${name}`;
       const body = optional(path.join(DATA_DICT, lang, name), key);
       if (body) {

--- a/tests/integration/api-index-xref-search.test.ts
+++ b/tests/integration/api-index-xref-search.test.ts
@@ -44,6 +44,17 @@ describe('/api/xref/{lang}.json', () => {
   });
 });
 
+describe('/api/xref-by-id/{lang}.json', () => {
+  it.each(['a', 't', 'h', 'c'])('returns an xref-by-id object (or {} fallback) for lang=%s', async (lang) => {
+    const res = await fetchFromServer(`/api/xref-by-id/${lang}.json`);
+    expect([200, 404]).toContain(res.status);
+    if (res.status === 200) {
+      const body = await res.json();
+      expect(body && typeof body === 'object' && !Array.isArray(body)).toBe(true);
+    }
+  });
+});
+
 describe('/api/search-index/{lang}.json', () => {
   it.each(['a', 't', 'h', 'c'])('returns array data for lang=%s when fixture present', async (lang) => {
     const res = await fetchFromServer(`/api/search-index/${lang}.json`);

--- a/tests/unit/api-dictionary-raw-uni-pua.test.ts
+++ b/tests/unit/api-dictionary-raw-uni-pua.test.ts
@@ -398,6 +398,61 @@ describe('getCrossReferences branches', () => {
   });
 });
 
+describe('getCrossReferencesById branches', () => {
+  it('returns [] when the xref-by-id file is absent', async () => {
+    const env = makeEnv({
+      [BUCKET_PATH]: makeBucketJson({ t: '萌', h: [{ b: 'ㄇㄥˊ', d: [{ f: '草芽' }] }] }),
+    });
+    const result = await lookupDictionaryEntry('萌', 'a', env);
+    expect(result).toBeTruthy();
+    expect(result?.xrefsByHeteronym).toEqual([]);
+  });
+
+  it('returns ID-grouped xrefs when the sidecar is present', async () => {
+    const env = makeEnv({
+      [BUCKET_PATH]: makeBucketJson({ t: '萌', h: [{ b: 'ㄇㄥˊ', d: [{ f: '草芽' }] }] }),
+      'a/xref-by-id.json': JSON.stringify({
+        t: { 萌: { '1': ['發穎', '初生'] } },
+      }),
+    });
+    const result = await lookupDictionaryEntry('萌', 'a', env);
+    expect(result?.xrefsByHeteronym).toEqual([
+      { lang: 't', byId: { '1': ['發穎', '初生'] } },
+    ]);
+  });
+
+  it('skips entries for other words', async () => {
+    const env = makeEnv({
+      [BUCKET_PATH]: makeBucketJson({ t: '萌', h: [{ b: 'ㄇㄥˊ', d: [{ f: '草芽' }] }] }),
+      'a/xref-by-id.json': JSON.stringify({
+        t: { 其他字: { '9': ['不相關'] } },
+      }),
+    });
+    const result = await lookupDictionaryEntry('萌', 'a', env);
+    expect(result?.xrefsByHeteronym).toEqual([]);
+  });
+
+  it('catches malformed xref-by-id JSON and returns []', async () => {
+    const env = makeEnv({
+      [BUCKET_PATH]: makeBucketJson({ t: '萌', h: [{ b: 'ㄇㄥˊ', d: [{ f: '草芽' }] }] }),
+      'a/xref-by-id.json': '<<< not valid JSON >>>',
+    });
+    const result = await lookupDictionaryEntry('萌', 'a', env);
+    expect(result?.xrefsByHeteronym).toEqual([]);
+  });
+
+  it('skips groups whose target lang is not a/t/h/c', async () => {
+    const env = makeEnv({
+      [BUCKET_PATH]: makeBucketJson({ t: '萌', h: [{ b: 'ㄇㄥˊ', d: [{ f: '草芽' }] }] }),
+      'a/xref-by-id.json': JSON.stringify({
+        garbage: { 萌: { '1': ['不應出現'] } },
+      }),
+    });
+    const result = await lookupDictionaryEntry('萌', 'a', env);
+    expect(result?.xrefsByHeteronym).toEqual([]);
+  });
+});
+
 describe('addBopomofo2 — tone + vowel-pick branch coverage', () => {
   // applyTone (inner helper) has a waterfall of `includes()` checks for
   // a / o / e / iu / ui / u / i / ü. Each branch needs both a "present"

--- a/tests/unit/worker-dispatch.test.ts
+++ b/tests/unit/worker-dispatch.test.ts
@@ -261,6 +261,27 @@ describe('dispatch — /api/xref/{lang}.json', () => {
   });
 });
 
+describe('dispatch — /api/xref-by-id/{lang}.json', () => {
+  it('serves xref-by-id JSON with xref cache headers', async () => {
+    const env = makeEnv({
+      DICTIONARY: makeBucket({ 't/xref-by-id.json': { body: '{"a":{}}' } }),
+    });
+    const res = await dispatch(req('/api/xref-by-id/t.json'), env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toContain('max-age=300');
+    expect(res.headers.get('cache-control')).toContain('s-maxage=3600');
+    expect(res.headers.get('cache-tag')).toContain('xref');
+    expect(res.headers.get('cache-tag')).toContain('xref-t');
+    expect(await res.text()).toBe('{"a":{}}');
+  });
+
+  it('returns empty-object JSON (not 404) when xref-by-id file is missing', async () => {
+    const res = await dispatch(req('/api/xref-by-id/t.json'), makeEnv());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('{}');
+  });
+});
+
 describe('dispatch — /manifest.appcache', () => {
   it('serves the manifest as text/cache-manifest', async () => {
     const env = makeEnv({

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -510,6 +510,37 @@ export async function dispatch(
         });
       }
 
+      // ID-aware xref sidecar（目前只有台語 t/xref-by-id.json）
+      const xrefByIdMatch = url.pathname.match(/^\/api\/xref-by-id\/([athc])\.json$/);
+      if (xrefByIdMatch) {
+        const lang = xrefByIdMatch[1];
+        const key = `${lang}/xref-by-id.json`;
+        const obj = await env.DICTIONARY.get(key);
+
+        if (!obj) {
+          return new Response('{}', {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8',
+              'Cache-Control': CACHE_CONTROL.xref,
+              'Cache-Tag': `xref,xref-${lang}`,
+              ...corsHeaders,
+            },
+          });
+        }
+
+        const content = await obj.text();
+        return new Response(content, {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Cache-Control': CACHE_CONTROL.xref,
+            'Cache-Tag': `xref,xref-${lang}`,
+            ...corsHeaders,
+          },
+        });
+      }
+
       // 筆順 JSON 代理（/api/stroke-json/{codepoint}.json）
       if (url.pathname.startsWith('/api/stroke-json/')) {
         return handleStrokeAPI(request, url, corsHeaders);


### PR DESCRIPTION
## Problem

Fixes [g0v/moedict-webkit#23](https://github.com/g0v/moedict-webkit/issues/23).

For polyphonic Taiwanese entries like `照`, the cross-references "依照、按照、證照" belong to the `tsià` reading (heteronym 9746) while "照" belongs to the `tsiò` reading (heteronym 9747). The legacy `t/xref.json` flattened these into `"依照,按照,,證照"`, losing the heteronym association.

## Prerequisite

Depends on [g0v/moedict-process#41](https://github.com/g0v/moedict-process/pull/41), which adds `t/xref-by-id.json` — an ID-aware sidecar generated from the same TWBLG CSV rows, grouping Mandarin words by `(taiwaneseTitle, heteronymId)`.

## Changes

### Worker (`worker/index.ts`)

New route `/api/xref-by-id/{lang}.json` serves `{lang}/xref-by-id.json` from R2 with the same cache policy and tags as the existing xref route.

### API handler (`src/api/handleDictionaryAPI.ts`)

New `getCrossReferencesById()` loads the sidecar and returns `Array<{ lang, byId: Record<heteronymId, string[]> }>`. Attached to every dictionary entry response as `xrefsByHeteronym`.

### Frontend (`src/pages/DictionaryPage.tsx`)

When `xrefsByHeteronym` data is available and a heteronym has an `id`, per-heteronym xref links are rendered inside that heteronym's block — placing "依照、按照、證照" beside the `tsià` reading and "照" beside the `tsiò` reading.

The flat bottom xref list is suppressed for languages that have ID-aware data (to avoid duplication). Languages without ID-aware sidecars continue to use the flat list unchanged.

### Tests

- `tests/unit/worker-dispatch.test.ts` — 2 new tests for the new route (serves JSON, returns `{}` when missing)
- `tests/unit/api-dictionary-raw-uni-pua.test.ts` — 5 new tests for `getCrossReferencesById` branches
- `tests/integration/api-index-xref-search.test.ts` — 4 new tests for the integration path
- `tests/helpers/fixtures.ts` — includes `xref-by-id.json` in seeded R2 fixtures

## Verification

```
bun run test:unit        → 1093 pass (0 fail)
bun run test:integration → 90 pass (0 fail)
bun run test:e2e         → 83 pass (0 fail)
bun run typecheck        → exit 0
```

## Deployment note

The `t/xref-by-id.json` file must be uploaded to the `moedict-dictionary` R2 bucket (and `moedict-dictionary-preview` for staging) before this change has visible effect. Upload is via `commands/upload_dictionary.sh` after merging and running `bun run pack` in `moedict-process`.