### PR TITLE
fix: eliminate production console font errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,13 @@ bun run deploy           # 驗證通過後才部署 production
   `https://r2-assets.moedict.tw`），**直接對該網域發 `<link>` 請求，完全繞過
   本 Worker**；`About.tsx` 自己另一份載入邏輯固定打相對路徑
   `/assets/styles.css`（Worker 代理 fallback）。兩者的 `loadCSS()` 都不會在
-  失敗時重試另一條路徑。**既有 Playwright e2e/visual 套件目前完全測不到這個
+  失敗時重試另一條路徑。兩條路徑都附加 `?v=20260711` 查詢參數
+  （`LEGACY_STYLESHEET_VERSION`，定義在 `src/utils/media-cdn.ts`）——這是
+  一次性快取命名空間，用來繞過 pre-existing 未版本化的 `styles.css` 物件
+  （edge 快取 `max-age=86400` / 24h）。**例行後續 data-only 上傳**只需重傳
+  R2 物件並設 `Cache-Control: public, max-age=300`（5 分鐘 edge TTL），
+  不必重佈 Worker、不必 bump 版本；bump `?v=` 僅用於緊急立即 bust 舊的
+  24h 快取物件。**既有 Playwright e2e/visual 套件目前完全測不到這個
   檔案**：測試環境的 `ASSET_BASE_URL` 是假網域 `r2-assets.test.local`，被
   `tests/e2e/_fixtures.ts` 全域擋成 404，`tests/helpers/fixtures.ts` 的
   `collectAssetFixtures()` 也沒把 styles.css 種進 Miniflare 的 ASSETS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,17 +178,21 @@ bun run deploy           # 驗證通過後才部署 production
   一次性快取命名空間，用來繞過 pre-existing 未版本化的 `styles.css` 物件
   （edge 快取 `max-age=86400` / 24h）。**例行後續 data-only 上傳**只需重傳
   R2 物件並設 `Cache-Control: public, max-age=300`（5 分鐘 edge TTL），
-  不必重佈 Worker、不必 bump 版本；bump `?v=` 僅用於緊急立即 bust 舊的
-  24h 快取物件。**既有 Playwright e2e/visual 套件目前完全測不到這個
+  不必重佈 Worker、不必 bump 版本；bump `?v=` 僅用於緊急立即 bust 任何過時
+  edge 快取的 stylesheet key（原始未版本化物件的 24h，或前一個 `?v=` 版本
+  仍快取在 5 分鐘 TTL）。**既有 Playwright e2e/visual 套件大多測不到這個
   檔案**：測試環境的 `ASSET_BASE_URL` 是假網域 `r2-assets.test.local`，被
   `tests/e2e/_fixtures.ts` 全域擋成 404，`tests/helpers/fixtures.ts` 的
   `collectAssetFixtures()` 也沒把 styles.css 種進 Miniflare 的 ASSETS
-  bucket——所以現有 `visual-snapshots.spec.ts` 的 baseline 全部是在「legacy
-  CSS 沒套用」的狀態下拍的。這是既有落差，不是本次改動造成，暫不處理（修這個
-  屬於獨立的測試基礎設施工作，範圍超出單一 CSS 檔案整理）。
+  bucket——所以 `visual-snapshots.spec.ts` 的 baseline 全部是在「legacy
+  CSS 沒套用」的狀態下拍的。**例外**：`legacy-styles-regression.spec.ts`
+  用 `page.route()` 攔截 styles.css（含 `?v=` 查詢版本）並灌入真實 CSS 做差分
+  比對；`console-load-errors.spec.ts` 同樣攔截並驗證載入。這兩個 spec 不受上述
+  404 限制。其餘既有落差不是本次改動造成，暫不處理（屬於獨立的測試基礎設施
+  工作，範圍超出單一 CSS 檔案整理）。
 - **驗證新/舊版 styles.css 是否零視覺差異，用
   `tests/e2e/legacy-styles-regression.spec.ts`**（新增，2026-07）：對每個代表
-  頁面，用 `page.route()` 攔截上述兩條 styles.css 請求路徑，先灌
+  頁面，用 `page.route()` 攔截上述兩條 styles.css 請求路徑（含 `?v=` 查詢版本），先灌
   `git show <ref>:data/assets/styles.css`、再灌 working tree 版本，比對兩次
   導覽後的 `getComputedStyle`（含 `::before`/`::after`，因為 Font
   Awesome/glyph 類選擇器幾乎全靠 `:before{content}` 呈現——純 PNG 截圖 diff

--- a/data/assets/styles.css
+++ b/data/assets/styles.css
@@ -9810,7 +9810,7 @@ a .icon-flip-vertical:before {
 
 @font-face {
   font-family: MOEDICT-IOS-KAI;
-  src: url(/private/var/mobile/Library/Assets/com_apple_MobileAsset_Font/9965d7058b88c289dece8eaaaf085f46bc3c5b87.asset/AssetData/BiauKai.ttf) format("truetype");
+  src: local(BiauKai);
 }
 
 .vowel-030d,

--- a/src/components/AssetLoader.tsx
+++ b/src/components/AssetLoader.tsx
@@ -100,26 +100,6 @@ function loadScript(src: string, id?: string): Promise<void> {
 		document.head.appendChild(script);
 	});
 }
-
-/**
- * 預載入字體
- */
-function preloadFont(href: string, as: string = 'font', type: string = 'font/woff'): void {
-	if (!href) return;
-
-	// 檢查是否已經載入過
-	const existing = document.querySelector(`link[rel="preload"][href="${href}"]`);
-	if (existing) return;
-
-	const link = document.createElement('link');
-	link.rel = 'preload';
-	link.href = href;
-	link.as = as;
-	link.type = type;
-	link.crossOrigin = 'anonymous';
-	document.head.appendChild(link);
-}
-
 /**
  * 資源載入組件
  */
@@ -160,12 +140,6 @@ export function AssetLoader({ r2Endpoint, onCriticalStylesReady }: AssetLoaderPr
 				onCriticalStylesReady?.();
 				setCriticalStylesNotified(true);
 			}
-
-			// 預載入字體
-			preloadFont(`${basePath}/fonts/MOEDICT.woff`, 'font', 'font/woff');
-			preloadFont(`${basePath}/fonts/han.woff`, 'font', 'font/woff');
-			preloadFont(`${basePath}/fonts/EBAS-Subset.woff`, 'font', 'font/woff');
-			preloadFont(`${basePath}/fonts/FiraSansOT-Regular.woff`, 'font', 'font/woff');
 
 			// 載入必要的 JS 檔案（順序載入）
 			try {

--- a/src/components/AssetLoader.tsx
+++ b/src/components/AssetLoader.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { LEGACY_STYLESHEET_VERSION } from '../utils/media-cdn';
 
 interface AssetLoaderProps {
 	r2Endpoint?: string;
@@ -152,7 +153,7 @@ export function AssetLoader({ r2Endpoint, onCriticalStylesReady }: AssetLoaderPr
 
 			// 載入 CSS 檔案
 			await Promise.all([
-				loadCSS(`${basePath}/styles.css`, 'styles-css'),
+				loadCSS(`${basePath}/styles.css?v=${LEGACY_STYLESHEET_VERSION}`, 'styles-css'),
 				loadCSS(`${basePath}/css/cupertino/jquery-ui-1.10.4.custom.css`, 'jquery-ui-css'),
 			]);
 			if (!criticalStylesNotified) {

--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -314,6 +314,10 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 			height: 1.8em;
 			box-sizing: border-box;
 			padding: 4px 8px;
+			font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, MOEDICT, "TW-Kai-98_1", "標楷體", serif;
+		}
+
+		html.moe-capacitor .query-box input.query {
 			font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 		}
 

--- a/src/index.css
+++ b/src/index.css
@@ -105,13 +105,17 @@ body {
 	color: #333;
 	font-size: 16px;
 	line-height: 1.4;
-  font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
+  font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 }
 
 .fulltext-search-input:focus {
 	outline: none;
 	border-color: #74b2e2;
 	box-shadow: 0 0 0 2px rgba(116, 178, 226, 0.18);
+}
+
+html.moe-capacitor .fulltext-search-input {
+  font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 }
 
 .fulltext-search-icon {
@@ -508,11 +512,11 @@ body[data-ruby-pref='zhuyin'] .result .entry .title {
 }
 
 .result .entry .title {
+  --title-leading-family: Biaodian Pro Serif CNS;
   --title-zhuyin-x-shift: 0em;
   --title-zhuyin-y-shift: 0em;
   font-family:
-    "MOE EduKai Android",
-    Biaodian Pro Serif CNS,
+    var(--title-leading-family),
     Numeral LF Serif,
     MOEDICT,
     Fira Sans OT,
@@ -541,6 +545,11 @@ body[data-ruby-pref='zhuyin'] .result .entry .title {
     cursive,
     serif;
   font-weight: 400;
+}
+
+/* Capacitor-only: prepend EduKai as the leading family */
+html.moe-capacitor .result .entry .title {
+  --title-leading-family: "MOE EduKai Android", Biaodian Pro Serif CNS;
 }
 
 html.moe-android .result .entry .title {
@@ -572,6 +581,13 @@ html.moe-ios .result .entry .title {
 .result .entry .title hruby.rightangle ru[zhuyin] zhuyin,
 .result .entry .title hruby.rightangle ru[zhuyin] yin,
 .result .entry .title hruby.rightangle ru[zhuyin] diao {
+  font-family: MOEDICT, "Zhuyin Kaiti", cursive, serif !important;
+}
+
+/* Capacitor-only: prepend EduKai to zhuyin stack */
+html.moe-capacitor .result .entry .title hruby.rightangle ru[zhuyin] zhuyin,
+html.moe-capacitor .result .entry .title hruby.rightangle ru[zhuyin] yin,
+html.moe-capacitor .result .entry .title hruby.rightangle ru[zhuyin] diao {
   font-family: "MOE EduKai Android", MOEDICT, "Zhuyin Kaiti", cursive, serif !important;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -64,6 +64,10 @@ function applyPlatformClasses() {
   const ua = navigator.userAgent;
   document.documentElement.classList.toggle('moe-android', /\bAndroid\b/i.test(ua));
   document.documentElement.classList.toggle('moe-ios', /\b(iPhone|iPad|iPod)\b/i.test(ua));
+  document.documentElement.classList.toggle(
+    'moe-capacitor',
+    Boolean((window as Window & { Capacitor?: unknown }).Capacitor),
+  );
 }
 
 // 在渲染前先修正 URL 和設置攔截器

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { SvgIcon } from '../components/SvgIcon';
 import { applyHeadByPath, applyHeadToDocument, resolveHeadByPath } from '../ssr/head';
-import './About.css';
+import { LEGACY_STYLESHEET_VERSION } from '../utils/media-cdn';
 
 // 動態載入外部樣式
 function loadExternalStyles(r2Endpoint: string) {
@@ -21,7 +21,7 @@ function loadExternalStyles(r2Endpoint: string) {
 	const link = document.createElement('link');
 	link.rel = 'stylesheet';
 	// 使用 /assets/ 路徑，讓 Worker 代理請求
-	link.href = `/assets/styles.css`;
+	link.href = `/assets/styles.css?v=${LEGACY_STYLESHEET_VERSION}`;
 	link.setAttribute('data-r2-styles', 'true');
 	document.head.appendChild(link);
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import { SvgIcon } from '../components/SvgIcon';
 import { applyHeadByPath, applyHeadToDocument, resolveHeadByPath } from '../ssr/head';
 import { LEGACY_STYLESHEET_VERSION } from '../utils/media-cdn';
+import './About.css';
 
 // 動態載入外部樣式
 function loadExternalStyles(r2Endpoint: string) {

--- a/src/utils/media-cdn.ts
+++ b/src/utils/media-cdn.ts
@@ -14,13 +14,15 @@
 export const ASSET_CDN_BASE = 'https://r2-assets.moedict.tw';
 
 /**
- * Cache-bust version for the legacy `data/assets/styles.css` stylesheet.
+ * Stable cache-bust version for the legacy `data/assets/styles.css` stylesheet.
  *
- * The stylesheet is served from R2 with `Cache-Control: max-age=86400` (24h
- * edge). Appending `?v=<version>` as a query parameter makes the edge treat
- * each version as a distinct cache key, so a new version busts the old object
- * without requiring a cache purge. Bump this when the stylesheet content
- * changes meaningfully (e.g. BiauKai src fix, EduKai gating).
+ * `?v=<version>` is a one-time cache namespace that bypasses the pre-existing
+ * unversioned `styles.css` object (edge-cached at `max-age=86400` / 24h).
+ * Routine future data-only uploads remain R2-only and rely on the object's
+ * own `Cache-Control: public, max-age=300` metadata (set by Task 3 on re-upload)
+ * for a short 5-minute edge TTL — no Worker redeploy needed for CSS-only edits.
+ * Bump this query version only for an emergency immediate bust of the old
+ * 24h-cached unversioned object.
  */
 export const LEGACY_STYLESHEET_VERSION = '20260711';
 

--- a/src/utils/media-cdn.ts
+++ b/src/utils/media-cdn.ts
@@ -21,8 +21,9 @@ export const ASSET_CDN_BASE = 'https://r2-assets.moedict.tw';
  * Routine future data-only uploads remain R2-only and rely on the object's
  * own `Cache-Control: public, max-age=300` metadata (set by Task 3 on re-upload)
  * for a short 5-minute edge TTL — no Worker redeploy needed for CSS-only edits.
- * Bump this query version only for an emergency immediate bust of the old
- * 24h-cached unversioned object.
+ * Bump this query version only for an emergency immediate bust of any stale
+ * edge-cached stylesheet key (the original unversioned object at 24h, or a
+ * prior `?v=` version still cached at the 5-minute TTL).
  */
 export const LEGACY_STYLESHEET_VERSION = '20260711';
 

--- a/src/utils/media-cdn.ts
+++ b/src/utils/media-cdn.ts
@@ -13,6 +13,17 @@
  */
 export const ASSET_CDN_BASE = 'https://r2-assets.moedict.tw';
 
+/**
+ * Cache-bust version for the legacy `data/assets/styles.css` stylesheet.
+ *
+ * The stylesheet is served from R2 with `Cache-Control: max-age=86400` (24h
+ * edge). Appending `?v=<version>` as a query parameter makes the edge treat
+ * each version as a distinct cache key, so a new version busts the old object
+ * without requiring a cache purge. Bump this when the stylesheet content
+ * changes meaningfully (e.g. BiauKai src fix, EduKai gating).
+ */
+export const LEGACY_STYLESHEET_VERSION = '20260711';
+
 /** 筆畫 JSON：`${STROKE_JSON_BASE_URL}/{codepoint-hex}.json` */
 export const STROKE_JSON_BASE_URL = `${ASSET_CDN_BASE}/stroke-json`;
 

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Page, Route } from '@playwright/test';
+import { expect, test } from './_fixtures';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const STYLES_CSS_PATH = path.join(REPO_ROOT, 'data', 'assets', 'styles.css');
+
+const EDUKAI_URL_PATTERN = '**/assets-legacy/fonts/edukai-*.ttf';
+const BIAUKAI_URL_PATTERN = '**/BiauKai.ttf*';
+
+// Intercept legacy styles.css the same way legacy-styles-regression.spec.ts does,
+// serving the current working-tree data/assets/styles.css so the MOEDICT-IOS-KAI
+// @font-face is present and exercises the BiauKai src URL.
+async function routeStylesCss(page: Page): Promise<void> {
+  const css = readFileSync(STYLES_CSS_PATH, 'utf-8');
+  const handler = (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/css; charset=utf-8',
+      headers: { 'Access-Control-Allow-Origin': '*', 'Cache-Control': 'no-store' },
+      body: css,
+    });
+  await page.route('https://r2-assets.test.local/styles.css', handler);
+  await page.route('**/assets/styles.css', handler);
+}
+
+// Block CSS sub-resources that would DNS-fail (same as legacy-styles-regression
+// blockCssSubresources) so networkidle can fire.
+async function blockCssSubresources(page: Page): Promise<void> {
+  const notFound = (route: Route) =>
+    route.fulfill({ status: 404, contentType: 'text/plain; charset=utf-8', body: '' });
+  await page.route('**/assets/fonts/**', notFound);
+  await page.route('**/assets/images/leather_x2.jpg', notFound);
+  await page.route('**/assets/images/subtle_stripes_x2.png', notFound);
+}
+
+test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
+  test('normal web load: no EduKai fetch, no console.error, no BiauKai decode', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    const edukaiRequests: string[] = [];
+    const biaukaiRequests: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await blockCssSubresources(page);
+    await routeStylesCss(page);
+
+    // Intercept (but don't block) EduKai and BiauKai requests to record them
+    // without letting them 502/DNS-fail — fulfill with 404 so the browser
+    // logs the error we're testing for, but networkidle still fires.
+    await page.route(EDUKAI_URL_PATTERN, (route) => {
+      edukaiRequests.push(route.request().url());
+      return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
+    });
+    await page.route(BIAUKAI_URL_PATTERN, (route) => {
+      biaukaiRequests.push(route.request().url());
+      return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
+    });
+
+    // Ensure NO window.Capacitor (normal web)
+    await page.addInitScript(() => {
+      // @ts-expect-error -- deliberately delete for normal-web simulation
+      delete window.Capacitor;
+    });
+
+    await page.goto('/%E8%90%8C');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => document.fonts.ready);
+
+    // --- EduKai assertions ---
+    expect(edukaiRequests, 'normal web load must NOT request the EduKai font').toEqual([]);
+    expect(consoleErrors, 'normal web load must have zero console.error').toEqual([]);
+    expect(pageErrors, 'normal web load must have zero pageerror').toEqual([]);
+    expect(biaukaiRequests, 'normal web load must NOT request the 0-byte BiauKai URL').toEqual([]);
+
+    // Computed font-family on .result .entry .title must NOT start with
+    // "MOE EduKai Android" — it should fall through to system Kaiti.
+    const titleFontFamily = await page.evaluate(() => {
+      const el = document.querySelector('.result .entry .title');
+      return el ? getComputedStyle(el).fontFamily : null;
+    });
+    expect(titleFontFamily, 'title element must exist on the page').not.toBeNull();
+    expect(titleFontFamily, 'title font-family must NOT include MOE EduKai Android on web')
+      .not.toContain('MOE EduKai Android');
+  });
+
+  test('Capacitor-simulated load: moe-capacitor class present, EduKai in font stack', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await blockCssSubresources(page);
+    await routeStylesCss(page);
+
+    // Simulate Capacitor runtime BEFORE the app's main.tsx runs
+    await page.addInitScript(() => {
+      // @ts-expect-error -- simulating Capacitor webview runtime
+      window.Capacitor = { isNative: true, getPlatform: () => 'ios' };
+    });
+
+    await page.goto('/%E8%90%8C');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => document.fonts.ready);
+
+    // moe-capacitor class must be present on <html>
+    const hasCapacitorClass = await page.evaluate(() =>
+      document.documentElement.classList.contains('moe-capacitor')
+    );
+    expect(hasCapacitorClass, 'html must have moe-capacitor class when window.Capacitor is set').toBe(true);
+
+    // Computed font-family on .result .entry .title MUST include "MOE EduKai Android"
+    const titleFontFamily = await page.evaluate(() => {
+      const el = document.querySelector('.result .entry .title');
+      return el ? getComputedStyle(el).fontFamily : null;
+    });
+    expect(titleFontFamily, 'title element must exist').not.toBeNull();
+    expect(titleFontFamily, 'Capacitor load must include MOE EduKai Android in computed font-family')
+      .toContain('MOE EduKai Android');
+
+    // No console errors from the Capacitor load either (the @font-face is
+    // present but the font file at /assets-legacy/ is intercepted by the
+    // test server; in real Capacitor it would be bundled locally).
+    // Note: we don't assert zero console errors here because the test server
+    // 404s the font file — the assertion is about the CSS stack, not the
+    // actual font fetch in the test environment.
+  });
+});

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -278,3 +278,57 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     }
   });
 });
+
+test.describe('bare home URL — no unused font preload hints', () => {
+  test('normal web load at /: zero link[rel=preload][as=font] for optional legacy fonts', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    const consoleWarnings: string[] = [];
+
+    collectConsoleErrors(page, consoleErrors);
+    // Capture warning-level messages matching the preload-not-used pattern
+    // if they appear; this is secondary evidence, not the primary assertion
+    // (the primary contract is zero preload hint elements in the DOM).
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning' && /preloaded using link preload but not used/i.test(msg.text())) {
+        consoleWarnings.push(msg.text());
+      }
+    });
+
+    await blockCssSubresources(page);
+    await routeStylesCss(page);
+
+    // Ensure NO window.Capacitor (normal web)
+    await page.addInitScript(() => {
+      // @ts-expect-error -- deliberately delete for normal-web simulation
+      delete window.Capacitor;
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => document.fonts.ready);
+
+    // Primary contract: AssetLoader must NOT insert any <link rel="preload"
+    // as="font"> elements for optional legacy fonts. The legacy @font-face
+    // rules in styles.css already lazy-load on actual glyph/family demand;
+    // unconditional preload hints waste downloads and trigger intermittent
+    // Chromium warnings ("preloaded using link preload but not used").
+    const preloadLinks = await page.evaluate(() => {
+      return Array.from(
+        document.querySelectorAll('link[rel="preload"][as="font"]'),
+      ).map((el) => ({
+        href: (el as HTMLLinkElement).href,
+        type: (el as HTMLLinkElement).type,
+      }));
+    });
+    expect(preloadLinks, 'bare home URL must have zero font preload hint elements').toEqual([]);
+
+    // Secondary: if any preload-not-used warnings appeared, log them for
+    // diagnostics — but the primary assertion above is the DOM contract.
+    if (consoleWarnings.length > 0) {
+      console.log(`[preload-warnings] ${consoleWarnings.length} warnings:\n${consoleWarnings.map((w) => '  ' + w).join('\n')}`);
+    }
+
+    // No console errors from the bare home load.
+    expect(consoleErrors, 'bare home URL must have zero console.error').toEqual([]);
+  });
+});

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -36,12 +36,19 @@ async function routeStylesCss(page: Page): Promise<{ loaded: () => boolean; urls
       body: css,
     });
   };
-  await page.route('https://r2-assets.test.local/styles.css*', handler);
-  await page.route('**/assets/styles.css*', handler);
+  // Tighter than styles.css* — two patterns: exact (no query) and query-only.
+  // styles.css* would also match styles.css.bak; styles.css?* matches only
+  // the versioned URL. Both are needed so RED (no query) and GREEN (with v)
+  // are intercepted without breaking interception.
+  await page.route('https://r2-assets.test.local/styles.css', handler);
+  await page.route('https://r2-assets.test.local/styles.css?*', handler);
+  await page.route('**/assets/styles.css', handler);
+  await page.route('**/assets/styles.css?*', handler);
   // When window.Capacitor is set, offline-api.ts intercepts /api/config and
   // returns assetBaseUrl: '/assets-legacy', so AssetLoader loads CSS from
   // /assets-legacy/styles.css — intercept that path too.
-  await page.route('**/assets-legacy/styles.css*', handler);
+  await page.route('**/assets-legacy/styles.css', handler);
+  await page.route('**/assets-legacy/styles.css?*', handler);
   return { loaded: () => loaded, urls };
 }
 

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -14,17 +14,47 @@ const BIAUKAI_URL_PATTERN = '**/BiauKai.ttf*';
 // Intercept legacy styles.css the same way legacy-styles-regression.spec.ts does,
 // serving the current working-tree data/assets/styles.css so the MOEDICT-IOS-KAI
 // @font-face is present and exercises the BiauKai src URL.
-async function routeStylesCss(page: Page): Promise<void> {
+// Returns a thunk that reports whether the intercepted CSS was actually requested,
+// so callers can prove the BiauKai no-request assertion is non-vacuous.
+async function routeStylesCss(page: Page): Promise<() => boolean> {
   const css = readFileSync(STYLES_CSS_PATH, 'utf-8');
-  const handler = (route: Route) =>
-    route.fulfill({
+  let loaded = false;
+  const handler = (route: Route) => {
+    loaded = true;
+    return route.fulfill({
       status: 200,
       contentType: 'text/css; charset=utf-8',
       headers: { 'Access-Control-Allow-Origin': '*', 'Cache-Control': 'no-store' },
       body: css,
     });
+  };
   await page.route('https://r2-assets.test.local/styles.css', handler);
   await page.route('**/assets/styles.css', handler);
+  // When window.Capacitor is set, offline-api.ts intercepts /api/config and
+  // returns assetBaseUrl: '/assets-legacy', so AssetLoader loads CSS from
+  // /assets-legacy/styles.css — intercept that path too.
+  await page.route('**/assets-legacy/styles.css', handler);
+  return () => loaded;
+}
+
+// Collect console.error messages, excluding noise from the fixture's intentional
+// r2-*.test.local 404 blocker (those 404s are harness artifacts, not the
+// EduKai/BiauKai behavior under test). App-origin errors (127.0.0.1, localhost,
+// or any non-r2 host) are always retained.
+function collectConsoleErrors(page: Page, consoleErrors: string[]): void {
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    const loc = msg.location();
+    const locUrl = loc.url ?? '';
+    if (locUrl) {
+      try {
+        if (new URL(locUrl).hostname === 'r2-assets.test.local') return;
+      } catch {
+        // Not a parseable URL — keep the message (could be a JS runtime error).
+      }
+    }
+    consoleErrors.push(msg.text());
+  });
 }
 
 // Block CSS sub-resources that would DNS-fail (same as legacy-styles-regression
@@ -44,13 +74,11 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     const edukaiRequests: string[] = [];
     const biaukaiRequests: string[] = [];
 
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(msg.text());
-    });
+    collectConsoleErrors(page, consoleErrors);
     page.on('pageerror', (err) => pageErrors.push(err.message));
 
     await blockCssSubresources(page);
-    await routeStylesCss(page);
+    const stylesCssLoaded = await routeStylesCss(page);
 
     // Intercept (but don't block) EduKai and BiauKai requests to record them
     // without letting them 502/DNS-fail — fulfill with 404 so the browser
@@ -78,6 +106,10 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     expect(edukaiRequests, 'normal web load must NOT request the EduKai font').toEqual([]);
     expect(consoleErrors, 'normal web load must have zero console.error').toEqual([]);
     expect(pageErrors, 'normal web load must have zero pageerror').toEqual([]);
+    // Sanity: the intercepted legacy styles.css must have actually loaded —
+    // otherwise the BiauKai no-request assertion is vacuous (the @font-face
+    // that triggers the fetch lives in that stylesheet).
+    expect(stylesCssLoaded(), 'legacy styles.css must be loaded to exercise BiauKai @font-face').toBe(true);
     expect(biaukaiRequests, 'normal web load must NOT request the 0-byte BiauKai URL').toEqual([]);
 
     // Computed font-family on .result .entry .title must NOT start with
@@ -93,12 +125,10 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
 
   test('Capacitor-simulated load: moe-capacitor class present, EduKai in font stack', async ({ page }) => {
     const consoleErrors: string[] = [];
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(msg.text());
-    });
+    collectConsoleErrors(page, consoleErrors);
 
     await blockCssSubresources(page);
-    await routeStylesCss(page);
+    const stylesCssLoaded = await routeStylesCss(page);
 
     // Simulate Capacitor runtime BEFORE the app's main.tsx runs
     await page.addInitScript(() => {
@@ -114,6 +144,10 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     const hasCapacitorClass = await page.evaluate(() =>
       document.documentElement.classList.contains('moe-capacitor')
     );
+    // Sanity: the intercepted legacy styles.css must have actually loaded —
+    // otherwise the font-family assertions are vacuous (the @font-face and
+    // legacy font stacks live in that stylesheet).
+    expect(stylesCssLoaded(), 'legacy styles.css must be loaded to exercise font stacks').toBe(true);
     expect(hasCapacitorClass, 'html must have moe-capacitor class when window.Capacitor is set').toBe(true);
 
     // Computed font-family on .result .entry .title MUST include "MOE EduKai Android"

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -80,16 +81,22 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     await blockCssSubresources(page);
     const stylesCssLoaded = await routeStylesCss(page);
 
-    // Intercept (but don't block) EduKai and BiauKai requests to record them
-    // without letting them 502/DNS-fail — fulfill with 404 so the browser
-    // logs the error we're testing for, but networkidle still fires.
+    // Intercept EduKai requests (record without DNS-fail) — fulfill with 404
+    // so the browser logs the error we're testing for, but networkidle fires.
     await page.route(EDUKAI_URL_PATTERN, (route) => {
       edukaiRequests.push(route.request().url());
       return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
     });
+    // Intercept BiauKai requests — fulfill as 0-byte font/ttf to reproduce
+    // the production R2 behavior (R2 serves a 0-byte body with font/ttf
+    // content-type, causing "Failed to decode downloaded font" warnings).
     await page.route(BIAUKAI_URL_PATTERN, (route) => {
       biaukaiRequests.push(route.request().url());
-      return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
+      return route.fulfill({
+        status: 200,
+        contentType: 'font/ttf',
+        body: Buffer.alloc(0),
+      });
     });
 
     // Ensure NO window.Capacitor (normal web)
@@ -102,15 +109,48 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     await page.waitForLoadState('networkidle');
     await page.evaluate(() => document.fonts.ready);
 
-    // --- EduKai assertions ---
-    expect(edukaiRequests, 'normal web load must NOT request the EduKai font').toEqual([]);
-    expect(consoleErrors, 'normal web load must have zero console.error').toEqual([]);
-    expect(pageErrors, 'normal web load must have zero pageerror').toEqual([]);
     // Sanity: the intercepted legacy styles.css must have actually loaded —
     // otherwise the BiauKai no-request assertion is vacuous (the @font-face
     // that triggers the fetch lives in that stylesheet).
     expect(stylesCssLoaded(), 'legacy styles.css must be loaded to exercise BiauKai @font-face').toBe(true);
-    expect(biaukaiRequests, 'normal web load must NOT request the 0-byte BiauKai URL').toEqual([]);
+
+    // Deterministically exercise the MOEDICT-IOS-KAI @font-face (whose src
+    // is the 0-byte BiauKai URL) via document.fonts.load. The title font
+    // stack lists Biaukai (local) before MOEDICT-IOS-KAI, so on macOS the
+    // browser may resolve Biaukai locally and never attempt the URL —
+    // document.fonts.load forces the browser to evaluate the named face
+    // directly, guaranteeing a URL fetch if the @font-face has a url() src.
+    // Also append a probe element whose sole family is MOEDICT-IOS-KAI.
+    await page.evaluate(async () => {
+      const probe = document.createElement('span');
+      probe.style.fontFamily = 'MOEDICT-IOS-KAI';
+      probe.style.position = 'absolute';
+      probe.style.visibility = 'hidden';
+      probe.textContent = '字';
+      document.body.appendChild(probe);
+      // Force the browser to attempt loading the MOEDICT-IOS-KAI face.
+      try {
+        await document.fonts.load('16px "MOEDICT-IOS-KAI"', '字');
+      } catch {
+        // load() rejects on decode failure — expected for 0-byte font.
+      }
+      await document.fonts.ready;
+    });
+
+    // --- BiauKai assertion (non-vacuous: document.fonts.load exercised the face) ---
+    // RED evidence: in the pre-fix state, biaukaiRequests MUST be non-empty
+    // (the @font-face src is a url(), so document.fonts.load triggers a
+    // network fetch). If this is empty, the assertion is vacuous — the
+    // @font-face was never exercised. After Task 2 changes src to
+    // local(BiauKai), no URL request is made and this passes.
+    // Use expect.soft so both BiauKai and EduKai failures are reported
+    // in a single RED run (both are independent root causes).
+    expect.soft(biaukaiRequests, 'normal web load must NOT request the 0-byte BiauKai URL').toEqual([]);
+
+    // --- EduKai assertions ---
+    expect.soft(edukaiRequests, 'normal web load must NOT request the EduKai font').toEqual([]);
+    expect(consoleErrors, 'normal web load must have zero console.error').toEqual([]);
+    expect(pageErrors, 'normal web load must have zero pageerror').toEqual([]);
 
     // Computed font-family on .result .entry .title must NOT start with
     // "MOE EduKai Android" — it should fall through to system Kaiti.

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -68,6 +68,46 @@ async function blockCssSubresources(page: Page): Promise<void> {
   await page.route('**/assets/images/subtle_stripes_x2.png', notFound);
 }
 
+// When window.Capacitor is set, offline-api.ts intercepts /api/* and serves
+// dictionary data from locally bundled files via originalFetch('/dictionary/...').
+// In the test environment these paths don't exist on the server, so route them
+// to the data/dictionary/ fixtures so the Capacitor-simulated page renders.
+async function routeDictionaryData(page: Page): Promise<void> {
+  const DATA_DICT = path.join(REPO_ROOT, 'data', 'dictionary');
+  await page.route('**/dictionary/**', (route: Route) => {
+    const reqUrl = route.request().url();
+    const url = new URL(reqUrl);
+    const key = url.pathname.replace(/^\/dictionary\//, '');
+    const filePath = path.join(DATA_DICT, key);
+    try {
+      const body = readFileSync(filePath);
+      return route.fulfill({
+        status: 200,
+        contentType: 'text/plain; charset=utf-8',
+        body: Buffer.from(body),
+      });
+    } catch {
+      return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
+    }
+  });
+  // Also route search-index and stroke-json that the offline API fetches
+  await page.route('**/search-index/**', (route: Route) => {
+    const url = new URL(route.request().url());
+    const key = url.pathname.replace(/^\/search-index\//, '');
+    const filePath = path.join(DATA_DICT, 'search-index', key);
+    try {
+      const body = readFileSync(filePath);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json; charset=utf-8',
+        body: Buffer.from(body),
+      });
+    } catch {
+      return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
+    }
+  });
+}
+
 test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
   test('normal web load: no EduKai fetch, no console.error, no BiauKai decode', async ({ page }) => {
     const consoleErrors: string[] = [];
@@ -169,6 +209,7 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
 
     await blockCssSubresources(page);
     const stylesCssLoaded = await routeStylesCss(page);
+    await routeDictionaryData(page);
 
     // Simulate Capacitor runtime BEFORE the app's main.tsx runs
     await page.addInitScript(() => {

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -15,13 +15,20 @@ const BIAUKAI_URL_PATTERN = '**/BiauKai.ttf*';
 // Intercept legacy styles.css the same way legacy-styles-regression.spec.ts does,
 // serving the current working-tree data/assets/styles.css so the MOEDICT-IOS-KAI
 // @font-face is present and exercises the BiauKai src URL.
-// Returns a thunk that reports whether the intercepted CSS was actually requested,
-// so callers can prove the BiauKai no-request assertion is non-vacuous.
-async function routeStylesCss(page: Page): Promise<() => boolean> {
+//
+// Route patterns accept optional query strings (glob `*`) so that versioned
+// URLs like `styles.css?v=20260711` are intercepted. Every intercepted URL is
+// recorded so the test can assert that each loaded legacy stylesheet URL
+// carries a stable non-empty `v` query parameter (cache-busting version).
+// Returns a thunk for whether the CSS was requested and an array of the
+// intercepted stylesheet URLs.
+async function routeStylesCss(page: Page): Promise<{ loaded: () => boolean; urls: string[] }> {
   const css = readFileSync(STYLES_CSS_PATH, 'utf-8');
   let loaded = false;
+  const urls: string[] = [];
   const handler = (route: Route) => {
     loaded = true;
+    urls.push(route.request().url());
     return route.fulfill({
       status: 200,
       contentType: 'text/css; charset=utf-8',
@@ -29,13 +36,13 @@ async function routeStylesCss(page: Page): Promise<() => boolean> {
       body: css,
     });
   };
-  await page.route('https://r2-assets.test.local/styles.css', handler);
-  await page.route('**/assets/styles.css', handler);
+  await page.route('https://r2-assets.test.local/styles.css*', handler);
+  await page.route('**/assets/styles.css*', handler);
   // When window.Capacitor is set, offline-api.ts intercepts /api/config and
   // returns assetBaseUrl: '/assets-legacy', so AssetLoader loads CSS from
   // /assets-legacy/styles.css — intercept that path too.
-  await page.route('**/assets-legacy/styles.css', handler);
-  return () => loaded;
+  await page.route('**/assets-legacy/styles.css*', handler);
+  return { loaded: () => loaded, urls };
 }
 
 // Collect console.error messages, excluding noise from the fixture's intentional
@@ -119,7 +126,7 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     page.on('pageerror', (err) => pageErrors.push(err.message));
 
     await blockCssSubresources(page);
-    const stylesCssLoaded = await routeStylesCss(page);
+    const { loaded: stylesCssLoaded, urls: stylesUrls } = await routeStylesCss(page);
 
     // Intercept EduKai requests (record without DNS-fail) — fulfill with 404
     // so the browser logs the error we're testing for, but networkidle fires.
@@ -201,6 +208,14 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     expect(titleFontFamily, 'title element must exist on the page').not.toBeNull();
     expect(titleFontFamily, 'title font-family must NOT include MOE EduKai Android on web')
       .not.toContain('MOE EduKai Android');
+
+    // Every loaded legacy stylesheet URL must carry a stable non-empty `v`
+    // query parameter so edge-cached old objects are bustable on deploy.
+    expect(stylesUrls.length, 'at least one legacy stylesheet must be loaded').toBeGreaterThanOrEqual(1);
+    for (const url of stylesUrls) {
+      const v = new URL(url).searchParams.get('v');
+      expect(v, `legacy stylesheet URL must have non-empty v param: ${url}`).toBeTruthy();
+    }
   });
 
   test('Capacitor-simulated load: moe-capacitor class present, EduKai in font stack', async ({ page }) => {
@@ -208,7 +223,7 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     collectConsoleErrors(page, consoleErrors);
 
     await blockCssSubresources(page);
-    const stylesCssLoaded = await routeStylesCss(page);
+    const { loaded: stylesCssLoaded, urls: stylesUrls } = await routeStylesCss(page);
     await routeDictionaryData(page);
 
     // Simulate Capacitor runtime BEFORE the app's main.tsx runs
@@ -246,5 +261,13 @@ test.describe('console load errors — EduKai 404 and BiauKai decode', () => {
     // Note: we don't assert zero console errors here because the test server
     // 404s the font file — the assertion is about the CSS stack, not the
     // actual font fetch in the test environment.
+
+    // Every loaded legacy stylesheet URL must carry a stable non-empty `v`
+    // query parameter so edge-cached old objects are bustable on deploy.
+    expect(stylesUrls.length, 'at least one legacy stylesheet must be loaded').toBeGreaterThanOrEqual(1);
+    for (const url of stylesUrls) {
+      const v = new URL(url).searchParams.get('v');
+      expect(v, `legacy stylesheet URL must have non-empty v param: ${url}`).toBeTruthy();
+    }
   });
 });

--- a/tests/e2e/console-load-errors.spec.ts
+++ b/tests/e2e/console-load-errors.spec.ts
@@ -83,14 +83,14 @@ async function routeDictionaryData(page: Page): Promise<void> {
       const body = readFileSync(filePath);
       return route.fulfill({
         status: 200,
-        contentType: 'text/plain; charset=utf-8',
+        contentType: 'application/json; charset=utf-8',
         body: Buffer.from(body),
       });
     } catch {
       return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
     }
   });
-  // Also route search-index and stroke-json that the offline API fetches
+  // Also route search-index that the offline API fetches
   await page.route('**/search-index/**', (route: Route) => {
     const url = new URL(route.request().url());
     const key = url.pathname.replace(/^\/search-index\//, '');

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -359,6 +359,20 @@ test.describe('special routes', () => {
     await expect(page).toHaveTitle(/關於本站/);
     await page.waitForLoadState('networkidle');
     await expect(page.locator('body')).toContainText(/萌典/, { timeout: 20_000 });
+
+    // About.css must be loaded — .about-page has a distinctive computed style
+    // (position: relative, min-height: 100vh) that proves the stylesheet is
+    // bundled and applied. Without import './About.css' these are default
+    // (position: static, min-height: auto) and the page layout breaks.
+    const aboutStyle = await page.evaluate(() => {
+      const el = document.querySelector('.about-page');
+      if (!el) return null;
+      const cs = getComputedStyle(el);
+      return { position: cs.position, minHeight: cs.minHeight };
+    });
+    expect(aboutStyle, '.about-page element must exist on /about').not.toBeNull();
+    expect(aboutStyle!.position, '.about-page must have position: relative from About.css').toBe('relative');
+    expect(aboutStyle!.minHeight, '.about-page must have min-height: 100vh from About.css').toBe('100vh');
   });
 
   test('/privacy shows privacy content', async ({ page }) => {

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -372,7 +372,9 @@ test.describe('special routes', () => {
     });
     expect(aboutStyle, '.about-page element must exist on /about').not.toBeNull();
     expect(aboutStyle!.position, '.about-page must have position: relative from About.css').toBe('relative');
-    expect(aboutStyle!.minHeight, '.about-page must have min-height: 100vh from About.css').toBe('100vh');
+    // min-height resolves to viewport pixels (800px at 1280×800 viewport);
+    // the key assertion is that it's not 'auto' (default without About.css).
+    expect(aboutStyle!.minHeight, '.about-page must have non-auto min-height from About.css').not.toBe('auto');
   });
 
   test('/privacy shows privacy content', async ({ page }) => {

--- a/tests/e2e/legacy-styles-regression.spec.ts
+++ b/tests/e2e/legacy-styles-regression.spec.ts
@@ -35,8 +35,16 @@ async function routeStylesCss(page: Page, getCss: () => string): Promise<void> {
       headers: { 'Access-Control-Allow-Origin': '*', 'Cache-Control': 'no-store' },
       body: getCss(),
     });
+  // Production appends ?v=<LEGACY_STYLESHEET_VERSION> (e.g. ?v=20260711) to
+  // bust the pre-existing unversioned edge-cached object. Register both the
+  // exact no-query URL and the query-bearing URL so the differential test
+  // intercepts the real production request instead of falling through to
+  // _fixtures.ts's blanket r2-*.test.local 404 (which would make both
+  // navigations identically unstyled → vacuously passing).
   await page.route('https://r2-assets.test.local/styles.css', handler);
+  await page.route('https://r2-assets.test.local/styles.css?*', handler);
   await page.route('**/assets/styles.css', handler); // About.tsx's own loader always uses this relative path
+  await page.route('**/assets/styles.css?*', handler);
 }
 
 // The CSS has relative url() references (fonts/, images/) that, when the


### PR DESCRIPTION
## Root Causes & Fixes

### 1. EduKai 404 on normal web
**Root cause:** `AssetLoader.tsx` unconditionally loaded a 15.1MB EduKai font from `/assets-legacy/fonts/edukai-*.ttf` — a path that only exists in the Capacitor app bundle, not on the web. Every normal-web page load produced a 404 console error.

**Fix:** Gate EduKai to Capacitor only. `main.tsx` now sets `html.moe-capacitor` class when `window.Capacitor` is present (never UA-sniffing `moe-android`). EduKai is removed from all 4 default font stacks (`src/index.css` ×3, `InlineStyles.tsx` ×1); Capacitor-scoped overrides add it back via `--title-leading-family` custom property.

### 2. BiauKai 0-byte decode in legacy CSS
**Root cause:** `data/assets/styles.css` `@font-face` for `MOEDICT-IOS-KAI` pointed at a remote `url()` that returned 0 bytes in production, causing a font decode error.

**Fix:** Changed `@font-face` src to `local(BiauKai)` in place — no deletion or reorder of `@font-face` rules.

### 3. Stale edge-cached unversioned `styles.css`
**Root cause:** The legacy `styles.css` R2 object was edge-cached at `max-age=86400` (24h) with no version query param. Bumping the file content did not bust the edge cache.

**Fix:** Added `LEGACY_STYLESHEET_VERSION = '20260711'` in `src/utils/media-cdn.ts`; both `AssetLoader.tsx` and `About.tsx` now append `?v=20260711` to the stylesheet URL. This is a stable one-time cache namespace — routine future data-only uploads rely on R2 object `Cache-Control: public, max-age=300` (5-minute edge TTL), no Worker redeploy needed.

### 4. Lost `import './About.css'`
**Root cause:** The edit adding `LEGACY_STYLESHEET_VERSION` import to `About.tsx` accidentally replaced `import './About.css'` instead of inserting after it. The `/about` page layout broke silently (`.about-page` defaulted to `position: static`, `min-height: auto`).

**Fix:** Restored `import './About.css'` alongside the version import. TDD: RED test asserting `.about-page` computed style (`position: relative`, non-`auto` `min-height`) → GREEN after restore.

### 5. Vacuous legacy-styles regression test
**Root cause:** `legacy-styles-regression.spec.ts` registered only exact no-query `styles.css` route patterns. Production now appends `?v=20260711`, so the real URL fell through to the blanket `r2-*.test.local` 404 — both navigations were identically unstyled → test vacuously passed.

**Fix:** Added `styles.css?*` query-bearing route patterns alongside exact no-query patterns. Positive control proves non-vacuous: 2 named-property diffs (navbar.min-height: 0px→50px, navbar-brand.height: 20px→50px).

### 6. Unused font preload hints (follow-up)
**Root cause:** `AssetLoader.tsx` unconditionally inserted 4 `<link rel="preload" as="font">` elements for MOEDICT.woff, han.woff, EBAS-Subset.woff, and FiraSansOT-Regular.woff. Chromium intermittently warned "preloaded using link preload but not used," and the hints wasted downloads on every page load. The legacy `@font-face` rules already lazy-load fonts on actual glyph/family demand.

**Fix:** Deleted the `preloadFont` helper and all four calls from `AssetLoader.tsx`. No `@font-face` CSS changed — on-demand loading preserved. TDD: RED test asserting zero `link[rel="preload"][as="font"]` elements at bare `/` (proved exactly 4 matching links) → GREEN after deletion.

## TDD Approach

RED tests committed separately before production fixes:
- `5d96da6` — RED: console load errors regression (EduKai 404 + BiauKai decode)
- `8dc1b1b` — RED: assert legacy stylesheet URLs carry `?v=` cache-bust param
- `e0ad650` — RED: assert `/about` has About.css computed style
- `4d6f15c` — RED: bare home URL must have zero font preload hint elements

Each RED was proven failing, then GREEN after production fix.

## Tests

### Baseline (before preload follow-up)

```
bun run test  # test:unit && test:integration && test:e2e
```

| Suite | Files | Tests | Status |
|---|---|---|---|
| Unit | 40 | 1119 | ✅ passed |
| Integration | 8 | 92 | ✅ passed |
| E2E | — | 94 | ✅ passed (1.9m) |
| **Total** | **48** | **1305** | **all passed** |

Exit status: `0`.

### Preload follow-up verification

| Check | Result |
|---|---|
| `bun run build` | PASS (JS 432.00→431.55 kB) |
| `bun run typecheck` | PASS |
| `bun run lint` | PASS |
| `bun run test:unit` | 40 files, 1119 tests — all passed |
| Console E2E (3 tests) | 3 passed (4.2s) |

## Deployment Verification

### Initial deployment
- **Staging version:** `e863ab33-92f1-4727-8f75-7b7237a776af`
- **Production version:** `236c9594-0da2-4d52-814c-14477ea21ee0`
- **Production audit:** 6 runs — zero `console.error`, zero `pageerror`, zero EduKai 404, zero BiauKai decode errors, zero failed font/stylesheet requests

### Preload follow-up deployment
- **Staging version:** `49754deb-6a7b-40ba-8520-848f474a6393`
- **Production version:** `ef0b9913-1297-4edc-a703-fb4af9a7d2d7`
- **Production audit:** 6 runs at bare home `/` — zero `console.error`, zero `console.warning` (including zero preload-not-used warnings), zero `pageerror`, zero failed/4xx-5xx requests, zero `link[rel="preload"][as="font"]` elements

- **R2 styles.css SHA-256:** `a14e0cc8509443a3ba660e8e2e95254296e3c74c833182edccb33ee175efbb68`
- **R2 Cache-Control:** `public, max-age=300` (5-minute edge TTL)

## Commits (13)

```
3bc29fb fix: remove unused font preload hints from AssetLoader
4d6f15c test: RED — bare home URL must have zero font preload hint elements
e1d2837 fix: intercept ?v= query in legacy-styles regression, correct emergency-bump wording
9ef2b42 fix: restore About.css import, tighten test routes, revise docs
e0ad650 test: RED — assert /about has About.css computed style
f884024 fix: version legacy stylesheet URL with v query param to bust edge cache
8dc1b1b test: RED — assert legacy stylesheet URLs carry v cache-bust param
3c385d5 test: fix contentType and comment in routeDictionaryData helper
dd6013a test: route dictionary data for Capacitor-simulated E2E
9822d45 fix: gate EduKai font to Capacitor, fix BiauKai 0-byte decode
c3422e9 test: strengthen BiauKai assertion — document.fonts.load + 0-byte font/ttf, expect.soft for dual RED evidence
d6774d6 test: address review — filter r2-host console noise, verify styles.css loaded (non-vacuous BiauKai assertion)
5d96da6 test: add RED regression for console load errors (EduKai 404 + BiauKai decode)
```
