### PR TITLE
fix(ci): satisfy vp check formatting on merge-conflict-resolved files

### DIFF
--- a/README_CDN.md
+++ b/README_CDN.md
@@ -5,6 +5,7 @@
 ## 一、Cloudflare R2 公開端點
 
 ### 1) 筆畫 JSON 與四本字典發音音檔（`src/utils/media-cdn.ts`）
+
 - CDN：`https://r2-assets.moedict.tw`（R2 bucket `moedict-assets`，同 `ASSET_BASE_URL`）
 - Key 版面：**MP3 是現行遷移與播放的 canonical 格式**；`playAudioUrl()` 會先試
   `.mp3`，只有 MP3 播放失敗才退回 `.ogg`，見 `audio-utils.ts` 的
@@ -23,6 +24,7 @@
   `STROKE_JSON_BASE_URL` / `AUDIO_CDN_MAP`；調整網域只需要改這一個檔案。
 
 ### 2) 前端資產（fonts / JS / CSS）
+
 - 變數：`ASSET_BASE_URL`
 - 目前設定（本機）：`https://pub-1808868ac1e14b13abe9e2800cace884.r2.dev`
   （正式站另有自訂網域 `https://r2-assets.moedict.tw`，見上）
@@ -31,13 +33,14 @@
 - 使用位置：`wrangler.jsonc`、`worker/index.ts`
 
 ### 3) 字典資料端點
-</antml：parameter>
+
 - 變數：`DICTIONARY_BASE_URL`
 - 目前設定（本機）：`https://pub-7e5ed83262e5403d85cb5a04ff841cf4.r2.dev`
 - 用途：透過 `/api/config` 回傳給前端作為字典資料來源設定
 - 使用位置：`wrangler.jsonc`、`worker/index.ts`
 
 ## 二、資料完整性（新增詞條的音檔/筆畫從哪裡來）
+
 R2 上的筆畫 JSON 與 MP3 音檔是**一次性遷移**的結果（見下方「已停用」一節），
 不是從 pack 資料自動推導/重建。`data/dictionary/{pack,ptck,phck,pcck}` 若因
 上游（moedict-data／twblg）同步新增了帶 `audio_id` 的詞條，其對應的
@@ -63,12 +66,12 @@ node commands/migrate-legacy-cdn-to-r2.mjs --extensions=mp3
 `commands/migrate-legacy-cdn-to-r2.mjs` 一次性遷移進上方的 R2 端點，程式碼中
 **不再有任何引用**。保留此記錄供未來追查資料來源／重新遷移使用。
 
-| 用途 | 舊 CDN（`*.rackcdn.com`） | 對應語言 |
-|---|---|---|
-| 筆畫 JSON | `829091573dd46381a321-9e8a43b8d3436eaf4353af683c892840.ssl.cf1` | 全部（a/t/h/c 詞條標題） |
-| 音檔 | `203146b5091e8f0aafda-15d41c68795720c6e932125f5ace0c70.ssl.cf1` | `a` 華語（`c` 兩岸沿用） |
-| 音檔 | `1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1` | `t` 臺灣台語 |
-| 音檔 | `a7ff62cf9d5b13408e72-351edcddf20c69da65316dd74d25951e.ssl.cf1` | `h` 臺灣客語（含腔調組合音檔） |
+| 用途      | 舊 CDN（`*.rackcdn.com`）                                       | 對應語言                       |
+| --------- | --------------------------------------------------------------- | ------------------------------ |
+| 筆畫 JSON | `829091573dd46381a321-9e8a43b8d3436eaf4353af683c892840.ssl.cf1` | 全部（a/t/h/c 詞條標題）       |
+| 音檔      | `203146b5091e8f0aafda-15d41c68795720c6e932125f5ace0c70.ssl.cf1` | `a` 華語（`c` 兩岸沿用）       |
+| 音檔      | `1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1` | `t` 臺灣台語                   |
+| 音檔      | `a7ff62cf9d5b13408e72-351edcddf20c69da65316dd74d25951e.ssl.cf1` | `h` 臺灣客語（含腔調組合音檔） |
 
 （舊版本文件曾把最後一列誤標為「閩南語」——臺灣的語言代碼對應請一律以
 `AGENTS.md` 開頭的語言代碼表為準：`t`=臺灣台語、`h`=臺灣客語。）

--- a/commands/migrate-legacy-cdn-to-r2.mjs
+++ b/commands/migrate-legacy-cdn-to-r2.mjs
@@ -31,74 +31,82 @@
  * .migration-state/legacy-cdn-progress.ndjson，已成功或已確認 404 的 key
  * 會被跳過；因暫時性錯誤失敗的 key 下次執行會重試。
  */
-import { readdirSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, appendFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { spawn } from 'node:child_process';
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  existsSync,
+  appendFileSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const STATE_DIR = join(REPO_ROOT, '.migration-state');
-const PROGRESS_FILE = join(STATE_DIR, 'legacy-cdn-progress.ndjson');
-const CACHE_DIR = join(STATE_DIR, 'main-cache');
-const BUCKET = 'moedict-assets';
-const WRANGLER_BIN = join(REPO_ROOT, 'node_modules/.bin/wrangler');
+const STATE_DIR = join(REPO_ROOT, ".migration-state");
+const PROGRESS_FILE = join(STATE_DIR, "legacy-cdn-progress.ndjson");
+const CACHE_DIR = join(STATE_DIR, "main-cache");
+const BUCKET = "moedict-assets";
+const WRANGLER_BIN = join(REPO_ROOT, "node_modules/.bin/wrangler");
 
 const HOSTS = {
-  stroke: 'https://829091573dd46381a321-9e8a43b8d3436eaf4353af683c892840.ssl.cf1.rackcdn.com',
-  a: 'https://203146b5091e8f0aafda-15d41c68795720c6e932125f5ace0c70.ssl.cf1.rackcdn.com',
-  t: 'https://1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1.rackcdn.com',
-  h: 'https://a7ff62cf9d5b13408e72-351edcddf20c69da65316dd74d25951e.ssl.cf1.rackcdn.com',
+  stroke: "https://829091573dd46381a321-9e8a43b8d3436eaf4353af683c892840.ssl.cf1.rackcdn.com",
+  a: "https://203146b5091e8f0aafda-15d41c68795720c6e932125f5ace0c70.ssl.cf1.rackcdn.com",
+  t: "https://1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1.rackcdn.com",
+  h: "https://a7ff62cf9d5b13408e72-351edcddf20c69da65316dd74d25951e.ssl.cf1.rackcdn.com",
 };
 
-const LANG_DIRS = { a: 'pack', t: 'ptck', h: 'phck', c: 'pcck' };
+const LANG_DIRS = { a: "pack", t: "ptck", h: "phck", c: "pcck" };
 
 // ---- CLI args ----
 const args = Object.fromEntries(
   process.argv.slice(2).map((a) => {
     const m = a.match(/^--([^=]+)(?:=(.*))?$/);
     return m ? [m[1], m[2] ?? true] : [a, true];
-  })
+  }),
 );
 const LIMIT = args.limit ? Number(args.limit) : Infinity;
 const CONCURRENCY = args.concurrency ? Number(args.concurrency) : 8;
-const REPORT_ONLY = !!args['report-only'];
-const CATEGORY_FILTER = args.categories ? String(args.categories).split(',') : null;
-const EXTENSION_FILTER = args.extensions ? new Set(String(args.extensions).split(',')) : null;
-const RATE_LIMIT = args['rate-limit'] ? Number(args['rate-limit']) : 900;
-const RATE_WINDOW_MS = args['rate-window-ms'] ? Number(args['rate-window-ms']) : 5 * 60 * 1000;
+const REPORT_ONLY = !!args["report-only"];
+const CATEGORY_FILTER = args.categories ? String(args.categories).split(",") : null;
+const EXTENSION_FILTER = args.extensions ? new Set(String(args.extensions).split(",")) : null;
+const RATE_LIMIT = args["rate-limit"] ? Number(args["rate-limit"]) : 900;
+const RATE_WINDOW_MS = args["rate-window-ms"] ? Number(args["rate-window-ms"]) : 5 * 60 * 1000;
 // 下載（Rackspace fetch）跟上傳（R2 PUT）拆成兩個獨立階段：下載完全不碰
 // Cloudflare R2 API，可以跟任何 R2 writer（包含這支腳本自己的另一個 mp3/ogg
 // 分類、或 repair-audio-from-moe.mjs）安全並行。--download-only 只抓+快取到
 // 本機；正常執行會優先讀本機快取，快取沒有才現場抓。
-const DOWNLOAD_ONLY = !!args['download-only'];
+const DOWNLOAD_ONLY = !!args["download-only"];
 
 // ---- 複刻 src/components/StrokeAnimation.tsx 的 extractStrokeWords() ----
 function extractStrokeWords(input) {
-  const plain = String(input || '')
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;|&#160;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
+  const plain = String(input || "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&nbsp;|&#160;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'");
-  const withoutParen = plain.replace(/[（(].*/, '').trim();
+  const withoutParen = plain.replace(/[（(].*/, "").trim();
   return Array.from(withoutParen)
     .filter((ch) => /\p{Script=Han}/u.test(ch))
-    .join('');
+    .join("");
 }
 
 // ---- 複刻 src/utils/audio-utils.ts 的 normalizeAudioIdByLang() ----
 function normalizeAudioIdByLang(lang, audioId) {
-  const normalized = String(audioId || '').trim();
-  if (!normalized) return '';
-  if (lang !== 't') return normalized;
-  if (/^\d{1,4}$/.test(normalized)) return normalized.padStart(5, '0');
+  const normalized = String(audioId || "").trim();
+  if (!normalized) return "";
+  if (lang !== "t") return normalized;
+  if (/^\d{1,4}$/.test(normalized)) return normalized.padStart(5, "0");
   return normalized;
 }
 
 // ---- 複刻 src/pages/DictionaryPage.tsx 的 parseHakkaReadings() 腔調解析 ----
-const DIALECT_ORDER = '四海大平安南';
+const DIALECT_ORDER = "四海大平安南";
 const hakkaMatcher = () => /([四海大平安南])[\u20DE\u20DF](\S+)/g;
 
 function buildManifest() {
@@ -107,25 +115,26 @@ function buildManifest() {
   const hakkaVariantKeys = new Set();
 
   for (const [lang, dir] of Object.entries(LANG_DIRS)) {
-    const fullDir = join(REPO_ROOT, 'data/dictionary', dir);
-    const files = readdirSync(fullDir).filter((f) => f.endsWith('.txt'));
+    const fullDir = join(REPO_ROOT, "data/dictionary", dir);
+    const files = readdirSync(fullDir).filter((f) => f.endsWith(".txt"));
     for (const f of files) {
-      const text = readFileSync(join(fullDir, f), 'utf8');
+      const text = readFileSync(join(fullDir, f), "utf8");
       const obj = JSON.parse(text);
       for (const key of Object.keys(obj)) {
         const entry = obj[key];
-        if (entry && typeof entry.t === 'string') {
-          for (const ch of extractStrokeWords(entry.t)) strokeCps.add(ch.codePointAt(0).toString(16));
+        if (entry && typeof entry.t === "string") {
+          for (const ch of extractStrokeWords(entry.t))
+            strokeCps.add(ch.codePointAt(0).toString(16));
         }
         const heteronyms = Array.isArray(entry?.h) ? entry.h : [];
         for (const het of heteronyms) {
-          const rawAudioId = het && het['='] ? String(het['=']) : '';
+          const rawAudioId = het && het["="] ? String(het["="]) : "";
           if (!rawAudioId) continue;
-          if (lang === 'a' || lang === 't' || lang === 'h') {
+          if (lang === "a" || lang === "t" || lang === "h") {
             audioIds[lang].add(normalizeAudioIdByLang(lang, rawAudioId));
           }
-          if (lang === 'h') {
-            const trs = String((het && (het['p'] ?? het['T'])) || '');
+          if (lang === "h") {
+            const trs = String((het && (het["p"] ?? het["T"])) || "");
             const m = hakkaMatcher();
             let mm;
             while ((mm = m.exec(trs))) {
@@ -142,23 +151,35 @@ function buildManifest() {
   // 明確只建立 MP3 task，避免不必要的第二次 R2 PUT。佇列順序依流量權重：
   // stroke（全語言共用）→ a（華語/兩岸）→ t（台語）→ h（客語腔調組合）。
   const AUDIO_EXTENSIONS = [
-    { ext: 'mp3', contentType: 'audio/mpeg' },
-    { ext: 'ogg', contentType: 'audio/ogg' },
+    { ext: "mp3", contentType: "audio/mpeg" },
+    { ext: "ogg", contentType: "audio/ogg" },
   ].filter(({ ext }) => !EXTENSION_FILTER || EXTENSION_FILTER.has(ext));
   const AUDIO_LANGS = [
-    { ids: audioIds.a, host: HOSTS.a, prefix: 'audio/a', catBase: 'audio-a' },
-    { ids: audioIds.t, host: HOSTS.t, prefix: 'audio/t', catBase: 'audio-t' },
-    { ids: hakkaVariantKeys, host: HOSTS.h, prefix: 'audio/h', catBase: 'audio-h-variant' },
+    { ids: audioIds.a, host: HOSTS.a, prefix: "audio/a", catBase: "audio-a" },
+    { ids: audioIds.t, host: HOSTS.t, prefix: "audio/t", catBase: "audio-t" },
+    { ids: hakkaVariantKeys, host: HOSTS.h, prefix: "audio/h", catBase: "audio-h-variant" },
   ];
 
   const tasks = [];
   for (const cp of strokeCps) {
-    tasks.push({ cat: 'stroke', key: cp, url: `${HOSTS.stroke}/${cp}.json`, r2Key: `stroke-json/${cp}.json`, contentType: 'application/json' });
+    tasks.push({
+      cat: "stroke",
+      key: cp,
+      url: `${HOSTS.stroke}/${cp}.json`,
+      r2Key: `stroke-json/${cp}.json`,
+      contentType: "application/json",
+    });
   }
   for (const { ids, host, prefix, catBase } of AUDIO_LANGS) {
     for (const { ext, contentType } of AUDIO_EXTENSIONS) {
       for (const id of ids) {
-        tasks.push({ cat: `${catBase}-${ext}`, key: id, url: `${host}/${id}.${ext}`, r2Key: `${prefix}/${id}.${ext}`, contentType });
+        tasks.push({
+          cat: `${catBase}-${ext}`,
+          key: id,
+          url: `${host}/${id}.${ext}`,
+          r2Key: `${prefix}/${id}.${ext}`,
+          contentType,
+        });
       }
     }
   }
@@ -169,14 +190,14 @@ function buildManifest() {
 function loadProgress() {
   const done = new Set(); // ok/404 -> 兩種模式都跳過
   const cachedSet = new Set(); // 已下載快取到本機，尚未上傳 -> download-only 模式跳過；
-                                // 正常（上傳）模式改讀快取檔，不用重打 Rackspace
+  // 正常（上傳）模式改讀快取檔，不用重打 Rackspace
   if (existsSync(PROGRESS_FILE)) {
-    const lines = readFileSync(PROGRESS_FILE, 'utf8').split('\n').filter(Boolean);
+    const lines = readFileSync(PROGRESS_FILE, "utf8").split("\n").filter(Boolean);
     for (const line of lines) {
       try {
         const rec = JSON.parse(line);
-        if (rec.status === 'ok' || rec.status === '404') done.add(`${rec.cat}:${rec.key}`);
-        else if (rec.status === 'cached') cachedSet.add(`${rec.cat}:${rec.key}`);
+        if (rec.status === "ok" || rec.status === "404") done.add(`${rec.cat}:${rec.key}`);
+        else if (rec.status === "cached") cachedSet.add(`${rec.cat}:${rec.key}`);
       } catch {
         /* 忽略壞行 */
       }
@@ -188,12 +209,12 @@ function loadProgress() {
 mkdirSync(STATE_DIR, { recursive: true });
 mkdirSync(CACHE_DIR, { recursive: true });
 function recordProgress(rec) {
-  appendFileSync(PROGRESS_FILE, JSON.stringify(rec) + '\n');
+  appendFileSync(PROGRESS_FILE, JSON.stringify(rec) + "\n");
 }
 function cachePath(task) {
   const dir = join(CACHE_DIR, task.cat);
   mkdirSync(dir, { recursive: true });
-  return join(dir, task.key.replace(/[^a-zA-Z0-9_.-]/g, '_'));
+  return join(dir, task.key.replace(/[^a-zA-Z0-9_.-]/g, "_"));
 }
 
 // ---- R2 寫入限流：平滑最小間隔，而非「配額用完就整批卡住」----
@@ -220,19 +241,23 @@ function putToR2(r2Key, bytes, contentType) {
     const child = spawn(
       WRANGLER_BIN,
       [
-        'r2', 'object', 'put', `${BUCKET}/${r2Key}`,
-        '--pipe', '--remote',
+        "r2",
+        "object",
+        "put",
+        `${BUCKET}/${r2Key}`,
+        "--pipe",
+        "--remote",
         `--content-type=${contentType}`,
-        '--cache-control=public, max-age=31536000, immutable',
+        "--cache-control=public, max-age=31536000, immutable",
       ],
-      { cwd: REPO_ROOT, stdio: ['pipe', 'pipe', 'pipe'] }
+      { cwd: REPO_ROOT, stdio: ["pipe", "pipe", "pipe"] },
     );
-    let stderr = '';
-    let stdout = '';
-    child.stdout.on('data', (d) => (stdout += d));
-    child.stderr.on('data', (d) => (stderr += d));
-    child.on('error', reject);
-    child.on('close', (code) => {
+    let stderr = "";
+    let stdout = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => {
       if (code === 0) resolve({ ok: true });
       else resolve({ ok: false, code, stderr, stdout });
     });
@@ -242,7 +267,7 @@ function putToR2(r2Key, bytes, contentType) {
 }
 
 function isRateLimited(text) {
-  return /429|rate.?limit|Too Many Requests|error code:?\s*971/i.test(text || '');
+  return /429|rate.?limit|Too Many Requests|error code:?\s*971/i.test(text || "");
 }
 
 async function fetchWithRetry(url, attempts = 3) {
@@ -282,17 +307,17 @@ async function processTask(task, stats) {
     try {
       dl = await fetchWithRetry(task.url);
     } catch (e) {
-      recordProgress({ cat: task.cat, key: task.key, status: 'failed', error: String(e) });
+      recordProgress({ cat: task.cat, key: task.key, status: "failed", error: String(e) });
       stats.failed++;
       return;
     }
     if (dl.status === 404) {
-      recordProgress({ cat: task.cat, key: task.key, status: '404' });
+      recordProgress({ cat: task.cat, key: task.key, status: "404" });
       stats.notFound++;
       return;
     }
     writeFileSync(cPath, dl.buf);
-    recordProgress({ cat: task.cat, key: task.key, status: 'cached', bytes: dl.buf.length });
+    recordProgress({ cat: task.cat, key: task.key, status: "cached", bytes: dl.buf.length });
     stats.uploaded++; // 沿用同一個計數器命名（下載階段的「完成」）
     stats.bytes += dl.buf.length;
     return;
@@ -307,12 +332,12 @@ async function processTask(task, stats) {
     try {
       dl = await fetchWithRetry(task.url);
     } catch (e) {
-      recordProgress({ cat: task.cat, key: task.key, status: 'failed', error: String(e) });
+      recordProgress({ cat: task.cat, key: task.key, status: "failed", error: String(e) });
       stats.failed++;
       return;
     }
     if (dl.status === 404) {
-      recordProgress({ cat: task.cat, key: task.key, status: '404' });
+      recordProgress({ cat: task.cat, key: task.key, status: "404" });
       stats.notFound++;
       return;
     }
@@ -325,11 +350,15 @@ async function processTask(task, stats) {
     await throttleR2Write();
     const put = await putToR2(task.r2Key, buf, task.contentType);
     if (put.ok) {
-      recordProgress({ cat: task.cat, key: task.key, status: 'ok', bytes: buf.length });
+      recordProgress({ cat: task.cat, key: task.key, status: "ok", bytes: buf.length });
       stats.uploaded++;
       stats.bytes += buf.length;
       if (isCached) {
-        try { unlinkSync(cPath); } catch { /* 不影響結果 */ }
+        try {
+          unlinkSync(cPath);
+        } catch {
+          /* 不影響結果 */
+        }
       }
       return;
     }
@@ -340,15 +369,22 @@ async function processTask(task, stats) {
       console.error(`[rate-limit] backing off ${cooldown}ms after ${task.cat}:${task.key}`);
       continue;
     }
-    console.error(`[r2-put-error] ${task.cat}:${task.key} attempt=${attempt} code=${put.code} stderr=${put.stderr.slice(0, 300)}`);
+    console.error(
+      `[r2-put-error] ${task.cat}:${task.key} attempt=${attempt} code=${put.code} stderr=${put.stderr.slice(0, 300)}`,
+    );
     await sleep(1000 * 2 ** attempt);
   }
-  recordProgress({ cat: task.cat, key: task.key, status: 'failed', error: 'r2 put exhausted retries' });
+  recordProgress({
+    cat: task.cat,
+    key: task.key,
+    status: "failed",
+    error: "r2 put exhausted retries",
+  });
   stats.failed++;
 }
 
 async function main() {
-  console.log('Deriving manifest from data/dictionary ...');
+  console.log("Deriving manifest from data/dictionary ...");
   let tasks = buildManifest();
   const byCat = {};
   for (const t of tasks) byCat[t.cat] = (byCat[t.cat] || 0) + 1;
@@ -359,11 +395,13 @@ async function main() {
   const before = tasks.length;
   tasks = tasks.filter((t) => !done.has(`${t.cat}:${t.key}`));
   if (DOWNLOAD_ONLY) tasks = tasks.filter((t) => !cachedSet.has(`${t.cat}:${t.key}`));
-  console.log(`Skipping ${before - tasks.length} already-processed (mode=${DOWNLOAD_ONLY ? 'download-only' : 'upload'}); ${tasks.length} remaining`);
+  console.log(
+    `Skipping ${before - tasks.length} already-processed (mode=${DOWNLOAD_ONLY ? "download-only" : "upload"}); ${tasks.length} remaining`,
+  );
   if (Number.isFinite(LIMIT)) tasks = tasks.slice(0, LIMIT);
 
   if (REPORT_ONLY) {
-    console.log('Report-only mode, exiting without network calls.');
+    console.log("Report-only mode, exiting without network calls.");
     return;
   }
 
@@ -379,7 +417,7 @@ async function main() {
       if (totalDone % 200 === 0) {
         const elapsedS = (Date.now() - startTime) / 1000;
         console.log(
-          `[progress] ${totalDone}/${tasks.length} | ok=${stats.uploaded} 404=${stats.notFound} failed=${stats.failed} | ${(stats.bytes / 1e6).toFixed(1)}MB | ${(totalDone / elapsedS).toFixed(2)}/s | rateLimitHits=${stats.rateLimitHits}`
+          `[progress] ${totalDone}/${tasks.length} | ok=${stats.uploaded} 404=${stats.notFound} failed=${stats.failed} | ${(stats.bytes / 1e6).toFixed(1)}MB | ${(totalDone / elapsedS).toFixed(2)}/s | rateLimitHits=${stats.rateLimitHits}`,
         );
       }
     }
@@ -387,7 +425,7 @@ async function main() {
 
   await Promise.all(Array.from({ length: CONCURRENCY }, worker));
 
-  console.log('=== DONE ===');
+  console.log("=== DONE ===");
   console.log(stats);
 }
 

--- a/commands/repair-audio-from-moe.mjs
+++ b/commands/repair-audio-from-moe.mjs
@@ -22,42 +22,53 @@
  * 刻意保守：MOE 是小型政府網站不是 CDN，請用適度 concurrency 與 R2 rate limit，
  * 不對它做無界並發轟炸。
  */
-import { readdirSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, appendFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { spawn } from 'node:child_process';
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  existsSync,
+  appendFileSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const STATE_DIR = join(REPO_ROOT, '.migration-state');
-const PROGRESS_FILE = join(STATE_DIR, 'moe-audio-repair-progress.ndjson');
-const CACHE_DIR = join(STATE_DIR, 'moe-mp3-cache');
-const BUCKET = 'moedict-assets';
-const WRANGLER_BIN = join(REPO_ROOT, 'node_modules/.bin/wrangler');
-const SUTIAN_BASE = 'https://sutian.moe.edu.tw';
+const STATE_DIR = join(REPO_ROOT, ".migration-state");
+const PROGRESS_FILE = join(STATE_DIR, "moe-audio-repair-progress.ndjson");
+const CACHE_DIR = join(STATE_DIR, "moe-mp3-cache");
+const BUCKET = "moedict-assets";
+const WRANGLER_BIN = join(REPO_ROOT, "node_modules/.bin/wrangler");
+const SUTIAN_BASE = "https://sutian.moe.edu.tw";
 
 const args = Object.fromEntries(
-  process.argv.slice(2).filter((a) => a.startsWith('--')).map((a) => {
-    const m = a.match(/^--([^=]+)(?:=(.*))?$/);
-    return m ? [m[1], m[2] ?? true] : [a, true];
-  })
+  process.argv
+    .slice(2)
+    .filter((a) => a.startsWith("--"))
+    .map((a) => {
+      const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+      return m ? [m[1], m[2] ?? true] : [a, true];
+    }),
 );
-const wordArgs = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const wordArgs = process.argv.slice(2).filter((a) => !a.startsWith("--"));
 const ALL = !!args.all;
 const LIMIT = args.limit ? Number(args.limit) : Infinity;
 const CONCURRENCY = args.concurrency ? Number(args.concurrency) : 5;
-const DELAY_MS = args['delay-ms'] ? Number(args['delay-ms']) : 300;
-const MP3_ONLY = !!args['mp3-only'];
+const DELAY_MS = args["delay-ms"] ? Number(args["delay-ms"]) : 300;
+const MP3_ONLY = !!args["mp3-only"];
 // 下載（搜尋 sutian + 抓音檔）跟上傳（R2 PUT）拆成兩個獨立階段：下載完全不碰
 // Cloudflare R2 API，可以跟任何其他 R2 writer（包含主遷移腳本）安全並行，不會
 // 疊加帳號層級的 write 額度風險。--download-only 只做下載+快取到本機，
 // 之後不加這個 flag 的正常執行會優先讀本機快取，快取沒有才現場抓。
-const DOWNLOAD_ONLY = !!args['download-only'];
+const DOWNLOAD_ONLY = !!args["download-only"];
 // 轉檔（mp3 快取 -> ogg 快取）也完全不碰 R2，可以跟任何 R2 writer 安全並行，
 // 也可以跟 --download-only 一起：先下載，轉檔可以在下載完成的項目上立刻開始。
-const TRANSCODE_ONLY = !!args['transcode-only'];
+const TRANSCODE_ONLY = !!args["transcode-only"];
 // 這支腳本跟主遷移腳本（migrate-legacy-cdn-to-r2.mjs）共用同一個 Cloudflare
 // 帳號的 R2 write 額度；MP3-only 模式避免無必要的第二次 OGG PUT。
-const R2_RATE_LIMIT = args['r2-rate-limit'] ? Number(args['r2-rate-limit']) : 300;
+const R2_RATE_LIMIT = args["r2-rate-limit"] ? Number(args["r2-rate-limit"]) : 300;
 const R2_RATE_WINDOW_MS = 300000;
 
 function sleep(ms) {
@@ -65,23 +76,27 @@ function sleep(ms) {
 }
 
 function findMissingAudioIdEntries(onlyWords) {
-  const fullDir = join(REPO_ROOT, 'data/dictionary/ptck');
-  const files = readdirSync(fullDir).filter((f) => f.endsWith('.txt'));
+  const fullDir = join(REPO_ROOT, "data/dictionary/ptck");
+  const files = readdirSync(fullDir).filter((f) => f.endsWith(".txt"));
   const wordSet = onlyWords ? new Set(onlyWords) : null;
   const out = [];
   for (const f of files) {
-    const text = readFileSync(join(fullDir, f), 'utf8');
+    const text = readFileSync(join(fullDir, f), "utf8");
     let obj;
-    try { obj = JSON.parse(text); } catch { continue; }
+    try {
+      obj = JSON.parse(text);
+    } catch {
+      continue;
+    }
     for (const key of Object.keys(obj)) {
       const entry = obj[key];
-      const plainTitle = String(entry?.t || '').replace(/[`~]/g, '');
+      const plainTitle = String(entry?.t || "").replace(/[`~]/g, "");
       if (wordSet && !wordSet.has(plainTitle)) continue;
       const het = Array.isArray(entry?.h) ? entry.h : [];
       for (const h of het) {
-        if (h['=']) continue; // 已有真正 audio_id，不需要修補
-        if (!h['_']) continue;
-        out.push({ title: plainTitle, id: String(h['_']) });
+        if (h["="]) continue; // 已有真正 audio_id，不需要修補
+        if (!h["_"]) continue;
+        out.push({ title: plainTitle, id: String(h["_"]) });
       }
     }
   }
@@ -91,14 +106,16 @@ function findMissingAudioIdEntries(onlyWords) {
 function loadProgress() {
   const done = new Set(); // 已上傳或已確認 MOE 也沒有 -> 兩種模式都跳過
   const downloaded = new Set(); // 已下載快取到本機，尚未上傳 -> download-only 模式跳過；
-                                 // 正常（上傳）模式改讀快取檔，不用重打 sutian
+  // 正常（上傳）模式改讀快取檔，不用重打 sutian
   if (existsSync(PROGRESS_FILE)) {
-    for (const line of readFileSync(PROGRESS_FILE, 'utf8').split('\n').filter(Boolean)) {
+    for (const line of readFileSync(PROGRESS_FILE, "utf8").split("\n").filter(Boolean)) {
       try {
         const rec = JSON.parse(line);
-        if (rec.status === 'uploaded' || rec.status === 'not-found-on-moe') done.add(rec.id);
-        else if (rec.status === 'downloaded') downloaded.add(rec.id);
-      } catch { /* skip */ }
+        if (rec.status === "uploaded" || rec.status === "not-found-on-moe") done.add(rec.id);
+        else if (rec.status === "downloaded") downloaded.add(rec.id);
+      } catch {
+        /* skip */
+      }
     }
   }
   return { done, downloaded };
@@ -106,13 +123,16 @@ function loadProgress() {
 mkdirSync(STATE_DIR, { recursive: true });
 mkdirSync(CACHE_DIR, { recursive: true });
 function recordProgress(rec) {
-  appendFileSync(PROGRESS_FILE, JSON.stringify(rec) + '\n');
+  appendFileSync(PROGRESS_FILE, JSON.stringify(rec) + "\n");
 }
 
 /** 從 sutian 搜尋結果 HTML 抓「完全符合」詞目對應的第一個 data-src 音檔路徑。 */
 function extractAudioPathForExactMatch(html, word) {
   // 逐一掃描 <a href="/zh-hant/su/{id}/">{word}</a> ... 後面最近一個 data-src="[...]"
-  const linkRe = new RegExp(`<a href="/zh-hant/su/(\\d+)/">\\s*${word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*</a>`, 'g');
+  const linkRe = new RegExp(
+    `<a href="/zh-hant/su/(\\d+)/">\\s*${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*</a>`,
+    "g",
+  );
   const linkMatch = linkRe.exec(html);
   if (!linkMatch) return null;
   const afterLink = html.slice(linkMatch.index);
@@ -153,7 +173,7 @@ async function throttleR2Write() {
 }
 
 function isRateLimited(text) {
-  return /429|rate.?limit|Too Many Requests|error code:?\s*971/i.test(text || '');
+  return /429|rate.?limit|Too Many Requests|error code:?\s*971/i.test(text || "");
 }
 
 let globalCooldownUntil = 0;
@@ -162,14 +182,29 @@ function putToR2Once(r2Key, bytes, contentType) {
   return new Promise((resolve, reject) => {
     const child = spawn(
       WRANGLER_BIN,
-      ['r2', 'object', 'put', `${BUCKET}/${r2Key}`, '--pipe', '--remote', `--content-type=${contentType}`, '--cache-control=public, max-age=31536000, immutable'],
-      { cwd: REPO_ROOT, stdio: ['pipe', 'pipe', 'pipe'] }
+      [
+        "r2",
+        "object",
+        "put",
+        `${BUCKET}/${r2Key}`,
+        "--pipe",
+        "--remote",
+        `--content-type=${contentType}`,
+        "--cache-control=public, max-age=31536000, immutable",
+      ],
+      { cwd: REPO_ROOT, stdio: ["pipe", "pipe", "pipe"] },
     );
-    const killTimer = setTimeout(() => child.kill('SIGKILL'), 30000);
-    let stderr = '';
-    child.stderr.on('data', (d) => (stderr += d));
-    child.on('error', (e) => { clearTimeout(killTimer); reject(e); });
-    child.on('close', (code) => { clearTimeout(killTimer); resolve(code === 0 ? { ok: true } : { ok: false, stderr }); });
+    const killTimer = setTimeout(() => child.kill("SIGKILL"), 30000);
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", (e) => {
+      clearTimeout(killTimer);
+      reject(e);
+    });
+    child.on("close", (code) => {
+      clearTimeout(killTimer);
+      resolve(code === 0 ? { ok: true } : { ok: false, stderr });
+    });
     child.stdin.write(bytes);
     child.stdin.end();
   });
@@ -196,16 +231,40 @@ async function putToR2(r2Key, bytes, contentType) {
 
 function transcodeToOgg(mp3Buf) {
   return new Promise((resolve, reject) => {
-    const child = spawn('ffmpeg', ['-hide_banner', '-loglevel', 'error', '-i', 'pipe:0', '-ac', '2', '-c:a', 'vorbis', '-strict', '-2', '-q:a', '4', '-f', 'ogg', 'pipe:1'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const killTimer = setTimeout(() => child.kill('SIGKILL'), 20000);
+    const child = spawn(
+      "ffmpeg",
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        "pipe:0",
+        "-ac",
+        "2",
+        "-c:a",
+        "vorbis",
+        "-strict",
+        "-2",
+        "-q:a",
+        "4",
+        "-f",
+        "ogg",
+        "pipe:1",
+      ],
+      {
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    const killTimer = setTimeout(() => child.kill("SIGKILL"), 20000);
     const chunks = [];
-    let stderr = '';
-    child.stdout.on('data', (d) => chunks.push(d));
-    child.stderr.on('data', (d) => (stderr += d));
-    child.on('error', (e) => { clearTimeout(killTimer); reject(e); });
-    child.on('close', (code) => {
+    let stderr = "";
+    child.stdout.on("data", (d) => chunks.push(d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", (e) => {
+      clearTimeout(killTimer);
+      reject(e);
+    });
+    child.on("close", (code) => {
       clearTimeout(killTimer);
       if (code === 0 && chunks.length) resolve(Buffer.concat(chunks));
       else reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(0, 300)}`));
@@ -231,7 +290,9 @@ async function transcodeOneFromCache(target, idx, total, stats) {
     const oggBuf = await transcodeToOgg(readFileSync(mp3Path));
     writeFileSync(oggPath, oggBuf);
     stats.uploaded++;
-    console.log(`[${idx + 1}/${total}] ${target.title} (${target.id}): 已轉檔 ogg，${oggBuf.length}B`);
+    console.log(
+      `[${idx + 1}/${total}] ${target.title} (${target.id}): 已轉檔 ogg，${oggBuf.length}B`,
+    );
   } catch (e) {
     stats.failed++;
     console.error(`[${idx + 1}/${total}] ${target.title} (${target.id}): 轉檔失敗 ${e}`);
@@ -246,7 +307,7 @@ async function processOne(target, idx, total, stats) {
       if (cached) return; // 已經有快取，理論上不會走到這裡（loadProgress 已濾掉）
       const audioPath = await searchSutian(target.title);
       if (!audioPath) {
-        recordProgress({ id: target.id, title: target.title, status: 'not-found-on-moe' });
+        recordProgress({ id: target.id, title: target.title, status: "not-found-on-moe" });
         stats.notFoundOnMoe++;
         console.log(`[${idx + 1}/${total}] ${target.title} (${target.id}): MOE 也沒有`);
         return;
@@ -255,22 +316,30 @@ async function processOne(target, idx, total, stats) {
       if (!audioRes.ok) throw new Error(`audio fetch HTTP ${audioRes.status}`);
       const buf = Buffer.from(await audioRes.arrayBuffer());
       writeFileSync(cachePath(target.id), buf);
-      recordProgress({ id: target.id, title: target.title, status: 'downloaded', moePath: audioPath, bytes: buf.length });
+      recordProgress({
+        id: target.id,
+        title: target.title,
+        status: "downloaded",
+        moePath: audioPath,
+        bytes: buf.length,
+      });
       stats.uploaded++; // 沿用同一個計數器命名（下載階段的「完成」）
-      console.log(`[${idx + 1}/${total}] ${target.title} (${target.id}): 已下載快取，來源=${audioPath}，${buf.length}B`);
+      console.log(
+        `[${idx + 1}/${total}] ${target.title} (${target.id}): 已下載快取，來源=${audioPath}，${buf.length}B`,
+      );
       await sleep(DELAY_MS);
       return;
     }
 
     // 正常（上傳）模式：本機快取存在就直接讀，不用再打 sutian
     let buf;
-    let audioPath = 'cache';
+    let audioPath = "cache";
     if (cached) {
       buf = readFileSync(cachePath(target.id));
     } else {
       audioPath = await searchSutian(target.title);
       if (!audioPath) {
-        recordProgress({ id: target.id, title: target.title, status: 'not-found-on-moe' });
+        recordProgress({ id: target.id, title: target.title, status: "not-found-on-moe" });
         stats.notFoundOnMoe++;
         console.log(`[${idx + 1}/${total}] ${target.title} (${target.id}): MOE 也沒有`);
         return;
@@ -281,26 +350,42 @@ async function processOne(target, idx, total, stats) {
     }
 
     // mp3 上傳跟 ogg 轉檔+上傳互不依賴（都只需要 buf），平行跑省一次 R2
-    const mp3Task = putToR2(`audio/t/${target.id}.mp3`, buf, 'audio/mpeg');
+    const mp3Task = putToR2(`audio/t/${target.id}.mp3`, buf, "audio/mpeg");
     let put;
     let oggResult = { ok: true, bytes: 0 };
     if (MP3_ONLY) {
       put = await mp3Task;
     } else if (existsSync(oggCachePath(target.id))) {
       const oggBuf = readFileSync(oggCachePath(target.id));
-      const oggTask = putToR2(`audio/t/${target.id}.ogg`, oggBuf, 'audio/ogg').then((r) => ({ ...r, bytes: oggBuf.length }));
+      const oggTask = putToR2(`audio/t/${target.id}.ogg`, oggBuf, "audio/ogg").then((r) => ({
+        ...r,
+        bytes: oggBuf.length,
+      }));
       [put, oggResult] = await Promise.all([mp3Task, oggTask]);
     } else {
       const oggTask = transcodeToOgg(buf)
-        .then((oggBuf) => putToR2(`audio/t/${target.id}.ogg`, oggBuf, 'audio/ogg').then((r) => ({ ...r, bytes: oggBuf.length })))
+        .then((oggBuf) =>
+          putToR2(`audio/t/${target.id}.ogg`, oggBuf, "audio/ogg").then((r) => ({
+            ...r,
+            bytes: oggBuf.length,
+          })),
+        )
         .catch((oggErr) => ({ ok: false, stderr: String(oggErr) }));
       [put, oggResult] = await Promise.all([mp3Task, oggTask]);
     }
     if (!put.ok) throw new Error(`R2 put failed: ${put.stderr?.slice(0, 200)}`);
     const oggBytes = oggResult.ok ? oggResult.bytes : 0;
-    if (!oggResult.ok) console.error(`  (ogg 失敗，mp3 已成功: ${oggResult.stderr?.slice(0, 150)})`);
+    if (!oggResult.ok)
+      console.error(`  (ogg 失敗，mp3 已成功: ${oggResult.stderr?.slice(0, 150)})`);
 
-    recordProgress({ id: target.id, title: target.title, status: 'uploaded', moePath: audioPath, bytes: buf.length, oggBytes });
+    recordProgress({
+      id: target.id,
+      title: target.title,
+      status: "uploaded",
+      moePath: audioPath,
+      bytes: buf.length,
+      oggBytes,
+    });
     stats.uploaded++;
     // MP3_ONLY 上傳跟 --transcode-only 常常同時跑（互不搶資源：上傳被 R2
     // 限流，轉檔吃 CPU）；若上傳一結束就砍 mp3 快取，還沒輪到的轉檔會找
@@ -308,12 +393,22 @@ async function processOne(target, idx, total, stats) {
     // （容量成本可忽略，~15k 檔 x 十幾 KB）；非 MP3_ONLY 模式當下已經把
     // ogg 一起處理完，才安全刪。
     if (cached && !MP3_ONLY) {
-      try { unlinkSync(cachePath(target.id)); } catch { /* 不影響結果 */ }
-      try { unlinkSync(oggCachePath(target.id)); } catch { /* 不影響結果 */ }
+      try {
+        unlinkSync(cachePath(target.id));
+      } catch {
+        /* 不影響結果 */
+      }
+      try {
+        unlinkSync(oggCachePath(target.id));
+      } catch {
+        /* 不影響結果 */
+      }
     }
-    console.log(`[${idx + 1}/${total}] ${target.title} (${target.id}): 已修補，來源=${audioPath}，mp3=${buf.length}B ogg=${oggBytes}B`);
+    console.log(
+      `[${idx + 1}/${total}] ${target.title} (${target.id}): 已修補，來源=${audioPath}，mp3=${buf.length}B ogg=${oggBytes}B`,
+    );
   } catch (e) {
-    recordProgress({ id: target.id, title: target.title, status: 'failed', error: String(e) });
+    recordProgress({ id: target.id, title: target.title, status: "failed", error: String(e) });
     stats.failed++;
     console.error(`[${idx + 1}/${total}] ${target.title} (${target.id}): 失敗 ${e}`);
   }
@@ -322,7 +417,9 @@ async function processOne(target, idx, total, stats) {
 
 async function main() {
   if (!ALL && wordArgs.length === 0) {
-    console.error('用法: node commands/repair-audio-from-moe.mjs <詞目...> 或 --all [--limit=N] [--concurrency=5]');
+    console.error(
+      "用法: node commands/repair-audio-from-moe.mjs <詞目...> 或 --all [--limit=N] [--concurrency=5]",
+    );
     process.exit(1);
   }
   let targets = findMissingAudioIdEntries(ALL ? null : wordArgs);
@@ -345,12 +442,14 @@ async function main() {
       }
     }
     await Promise.all(Array.from({ length: CONCURRENCY }, transcodeWorker));
-    console.log('=== 轉檔完成 ===', { transcoded: stats.uploaded, failed: stats.failed });
+    console.log("=== 轉檔完成 ===", { transcoded: stats.uploaded, failed: stats.failed });
     return;
   }
 
   if (DOWNLOAD_ONLY) targets = targets.filter((t) => !downloaded.has(t.id));
-  console.log(`跳過已處理 ${done.size} 筆、已快取 ${downloaded.size} 筆；剩餘 ${targets.length} 筆（mode=${DOWNLOAD_ONLY ? 'download-only' : 'upload'}, concurrency=${CONCURRENCY}, R2 rate=${R2_RATE_LIMIT}/${R2_RATE_WINDOW_MS}ms）`);
+  console.log(
+    `跳過已處理 ${done.size} 筆、已快取 ${downloaded.size} 筆；剩餘 ${targets.length} 筆（mode=${DOWNLOAD_ONLY ? "download-only" : "upload"}, concurrency=${CONCURRENCY}, R2 rate=${R2_RATE_LIMIT}/${R2_RATE_WINDOW_MS}ms）`,
+  );
   if (Number.isFinite(LIMIT)) targets = targets.slice(0, LIMIT);
 
   const stats = { uploaded: 0, notFoundOnMoe: 0, failed: 0 };
@@ -362,7 +461,7 @@ async function main() {
     }
   }
   await Promise.all(Array.from({ length: CONCURRENCY }, worker));
-  console.log('=== 完成 ===', stats);
+  console.log("=== 完成 ===", stats);
 }
 
 main().catch((e) => {

--- a/src/components/user-pref.tsx
+++ b/src/components/user-pref.tsx
@@ -50,8 +50,8 @@ const PINYIN_T_OPTIONS: PrefOption[] = [
 ];
 
 const BOPOMOFO_SANDHI_T_OPTIONS: PrefOption[] = [
-	{ value: 'off', label: '本調（辭典標注）' },
-	{ value: 'sandhi', label: '自動推算連讀變調（約略）' },
+  { value: "off", label: "本調（辭典標注）" },
+  { value: "sandhi", label: "自動推算連讀變調（約略）" },
 ];
 
 const PINYIN_H_OPTIONS: PrefOption[] = [
@@ -181,7 +181,9 @@ export function UserPref() {
   const [pinyinA, setPinyinA] = useState(() => getStoredPref("pinyin_a", "HanYu"));
   const [pinyinT, setPinyinT] = useState(() => getStoredPref("pinyin_t", "TL"));
   const [pinyinH, setPinyinH] = useState(() => getStoredPref("pinyin_h", "TH"));
-  const [bopomofoSandhiT, setBopomofoSandhiT] = useState(() => getStoredPref("bopomofo_sandhi_t", "off"));
+  const [bopomofoSandhiT, setBopomofoSandhiT] = useState(() =>
+    getStoredPref("bopomofo_sandhi_t", "off"),
+  );
   const [fontSize, setFontSize] = useState<number>(() => readFontSize());
 
   useEffect(() => {

--- a/src/utils/media-cdn.ts
+++ b/src/utils/media-cdn.ts
@@ -13,7 +13,7 @@
  * 若未來調整網域，這是唯一該改的地方；handleStrokeAPI.ts、audio-utils.ts、
  * DictionaryPage.tsx、offline-api.ts、vite.config.ts 都從這裡 import。
  */
-export const ASSET_CDN_BASE = 'https://r2-assets.moedict.tw';
+export const ASSET_CDN_BASE = "https://r2-assets.moedict.tw";
 
 /**
  * Stable cache-bust version for the legacy `data/assets/styles.css` stylesheet.
@@ -27,7 +27,7 @@ export const ASSET_CDN_BASE = 'https://r2-assets.moedict.tw';
  * edge-cached stylesheet key (the original unversioned object at 24h, or a
  * prior `?v=` version still cached at the 5-minute TTL).
  */
-export const LEGACY_STYLESHEET_VERSION = '20260711';
+export const LEGACY_STYLESHEET_VERSION = "20260711";
 
 /** 筆畫 JSON：`${STROKE_JSON_BASE_URL}/{codepoint-hex}.json` */
 export const STROKE_JSON_BASE_URL = `${ASSET_CDN_BASE}/stroke-json`;
@@ -38,7 +38,7 @@ export const STROKE_JSON_BASE_URL = `${ASSET_CDN_BASE}/stroke-json`;
  * 客語（`h`）另有腔調組合音檔 `${AUDIO_CDN_MAP.h}/{variant}-{audioId}.ogg`
  * （見 DictionaryPage.tsx 的 getHakkaVariantAudioUrl / parseHakkaReadings）。
  */
-export const AUDIO_CDN_MAP: Record<'a' | 't' | 'h' | 'c', string> = {
+export const AUDIO_CDN_MAP: Record<"a" | "t" | "h" | "c", string> = {
   a: `${ASSET_CDN_BASE}/audio/a`,
   t: `${ASSET_CDN_BASE}/audio/t`,
   h: `${ASSET_CDN_BASE}/audio/h`,

--- a/tests/unit/user-pref.test.tsx
+++ b/tests/unit/user-pref.test.tsx
@@ -8,109 +8,106 @@
  * routes must not show it (a/c/h have no derived bopomofo to toggle).
  */
 
-import { act } from 'react';
-import { createRoot, type Root } from 'react-dom/client';
-import { flushSync } from 'react-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { UserPref } from '../../src/components/user-pref';
+import { UserPref } from "../../src/components/user-pref";
 
 let container: HTMLDivElement;
 let root: Root;
 
 beforeEach(() => {
-	window.localStorage.clear();
-	container = document.createElement('div');
-	document.body.appendChild(container);
-	root = createRoot(container);
-	vi.spyOn(console, 'error').mockImplementation((msg: unknown, ...rest: unknown[]) => {
-		if (typeof msg === 'string' && msg.includes('not wrapped in act')) return;
-		console.error(msg, ...rest);
-	});
+  window.localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.spyOn(console, "error").mockImplementation((msg: unknown, ...rest: unknown[]) => {
+    if (typeof msg === "string" && msg.includes("not wrapped in act")) return;
+    console.error(msg, ...rest);
+  });
 });
 
 afterEach(() => {
-	root.unmount();
-	container.remove();
-	vi.restoreAllMocks();
+  root.unmount();
+  container.remove();
+  vi.restoreAllMocks();
 });
 
 function renderPref(pathname: string): void {
-	act(() => {
-		flushSync(() => {
-			root.render(
-				<MemoryRouter initialEntries={[pathname]}>
-					<UserPref />
-				</MemoryRouter>,
-			);
-		});
-	});
+  act(() => {
+    flushSync(() => {
+      root.render(
+        <MemoryRouter initialEntries={[pathname]}>
+          <UserPref />
+        </MemoryRouter>,
+      );
+    });
+  });
 }
 
 function getSandhiSelect(): HTMLSelectElement | null {
-	return container.querySelector<HTMLSelectElement>('#pref-select-bopomofo_sandhi_t');
+  return container.querySelector<HTMLSelectElement>("#pref-select-bopomofo_sandhi_t");
 }
 
-describe('UserPref — bopomofo_sandhi_t toggle', () => {
-	it('shows the 方音符號聲調 control on the Taiwanese route (/\')', () => {
-		renderPref("/'tāi-gí");
+describe("UserPref — bopomofo_sandhi_t toggle", () => {
+  it("shows the 方音符號聲調 control on the Taiwanese route (/')", () => {
+    renderPref("/'tāi-gí");
 
-		const select = getSandhiSelect();
-		expect(select).not.toBeNull();
-		expect(select!.value).toBe('off'); // citation is the default per MOE spec
-	});
+    const select = getSandhiSelect();
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe("off"); // citation is the default per MOE spec
+  });
 
-	it('reflects a stored "off" value as the active selection', () => {
-		window.localStorage.setItem('bopomofo_sandhi_t', 'off');
-		renderPref("/'tāi-gí");
+  it('reflects a stored "off" value as the active selection', () => {
+    window.localStorage.setItem("bopomofo_sandhi_t", "off");
+    renderPref("/'tāi-gí");
 
-		const select = getSandhiSelect();
-		expect(select).not.toBeNull();
-		expect(select!.value).toBe('off');
-	});
+    const select = getSandhiSelect();
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe("off");
+  });
 
-	it('reflects a stored "sandhi" value as the active selection', () => {
-		window.localStorage.setItem('bopomofo_sandhi_t', 'sandhi');
-		renderPref("/'tāi-gí");
+  it('reflects a stored "sandhi" value as the active selection', () => {
+    window.localStorage.setItem("bopomofo_sandhi_t", "sandhi");
+    renderPref("/'tāi-gí");
 
-		const select = getSandhiSelect();
-		expect(select).not.toBeNull();
-		expect(select!.value).toBe('sandhi');
-	});
+    const select = getSandhiSelect();
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe("sandhi");
+  });
 
-	it('persists the new value to localStorage and triggers reload on change', () => {
-		renderPref("/'tāi-gí");
-		const select = getSandhiSelect();
-		expect(select).not.toBeNull();
+  it("persists the new value to localStorage and triggers reload on change", () => {
+    renderPref("/'tāi-gí");
+    const select = getSandhiSelect();
+    expect(select).not.toBeNull();
 
-		const reloadSpy = vi.fn();
-		vi.stubGlobal('location', { ...window.location, reload: reloadSpy });
+    const reloadSpy = vi.fn();
+    vi.stubGlobal("location", { ...window.location, reload: reloadSpy });
 
-		act(() => {
-			const setter = Object.getOwnPropertyDescriptor(
-				HTMLSelectElement.prototype,
-				'value',
-			)?.set;
-			setter!.call(select, 'sandhi');
-			select!.dispatchEvent(new Event('change', { bubbles: true }));
-		});
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
+      setter!.call(select, "sandhi");
+      select!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
 
-		expect(window.localStorage.getItem('bopomofo_sandhi_t')).toBe('sandhi');
-		expect(reloadSpy).toHaveBeenCalled();
-	});
+    expect(window.localStorage.getItem("bopomofo_sandhi_t")).toBe("sandhi");
+    expect(reloadSpy).toHaveBeenCalled();
+  });
 
-	it('does not show the control on the Mandarin route (/)', () => {
-		renderPref('/萌');
-		expect(getSandhiSelect()).toBeNull();
-	});
+  it("does not show the control on the Mandarin route (/)", () => {
+    renderPref("/萌");
+    expect(getSandhiSelect()).toBeNull();
+  });
 
-	it('does not show the control on the Hakka route (/:)', () => {
-		renderPref('/:客語');
-		expect(getSandhiSelect()).toBeNull();
-	});
+  it("does not show the control on the Hakka route (/:)", () => {
+    renderPref("/:客語");
+    expect(getSandhiSelect()).toBeNull();
+  });
 
-	it('does not show the control on the cross-strait route (/~)', () => {
-		renderPref('/~兩岸');
-		expect(getSandhiSelect()).toBeNull();
-	});
+  it("does not show the control on the cross-strait route (/~)", () => {
+    renderPref("/~兩岸");
+    expect(getSandhiSelect()).toBeNull();
+  });
 });

--- a/重要路由筆記.md
+++ b/重要路由筆記.md
@@ -1,9 +1,9 @@
 http-map =
-  a: https://203146b5091e8f0aafda-15d41c68795720c6e932125f5ace0c70.ssl.cf1.rackcdn.com
-  h: https://a7ff62cf9d5b13408e72-351edcddf20c69da65316dd74d25951e.ssl.cf1.rackcdn.com
-  t: https://1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1.rackcdn.com
-  'stroke-json': https://829091573dd46381a321-9e8a43b8d3436eaf4353af683c892840.ssl.cf1.rackcdn.com
-  stroke: https://626a26a628fa127d6a25-47cac8eba79cfb787dbcc3e49a1a65f1.ssl.cf1.rackcdn.com
+a: https://203146b5091e8f0aafda-15d41c68795720c6e932125f5ace0c70.ssl.cf1.rackcdn.com
+h: https://a7ff62cf9d5b13408e72-351edcddf20c69da65316dd74d25951e.ssl.cf1.rackcdn.com
+t: https://1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1.rackcdn.com
+'stroke-json': https://829091573dd46381a321-9e8a43b8d3436eaf4353af683c892840.ssl.cf1.rackcdn.com
+stroke: https://626a26a628fa127d6a25-47cac8eba79cfb787dbcc3e49a1a65f1.ssl.cf1.rackcdn.com
 
 ---
 


### PR DESCRIPTION
## 背景

PR #134（Rackspace → R2 CDN 遷移）合併後，CI 的 `vp check` 步驟失敗
（[run #64](https://github.com/g0v/moedict.tw/actions/runs/29187852051/job/86637095307)）。
`vp check` 是 CI 實際使用的格式檢查工具，跟我先前本機跑過、已過關的 `vp lint`
是不同指令——`vp check` 額外做格式化檢查（引號風格、縮排等），而 PR #134
merge 時手動解決衝突的 7 個檔案沿用了工具鏈遷移前的舊格式（單引號／tab
縮排），未跟上新的雙引號／2-space 慣例。

## 變更

對這 7 個檔案跑 `vp check --fix`：
- `README_CDN.md`
- `commands/migrate-legacy-cdn-to-r2.mjs`
- `commands/repair-audio-from-moe.mjs`
- `src/components/user-pref.tsx`
- `src/utils/media-cdn.ts`
- `tests/unit/user-pref.test.tsx`
- `重要路由筆記.md`

純格式修正，逐檔比對 diff 確認無邏輯變化。過程中額外發現並修正一處
`README_CDN.md` 裡殘留的工具呼叫錯字雜訊（`</antml：parameter>`，先前
手動解衝突時的複製貼上失誤，在 rendered markdown 中不可見），已一併移除。

## 驗證

- `vp check` — 0 error（159 個檔案，僅既有 4 個 warning，與此次修正無關）
- `bun run typecheck` — 乾淨
- `bun run test:unit` — 1134/1134 通過
- `bun run test:integration` — 93/93 通過
- `bun run build` — 成功
