### PR TITLE
fix: make deterministic Worker version tags idempotent

### DIFF
--- a/notes/零停機部署筆記.md
+++ b/notes/零停機部署筆記.md
@@ -88,6 +88,16 @@ production 在任何 mutating Wrangler call 之前，必須找到 staging 已成
 
 因此「同一份 source」不夠，必須是同一個 git SHA + 同一個 manifest digest。state 的 current/version history 應按 environment 分隔；shared `staging-approval.json` 只供 production 讀 gate。
 
+### 5.1a 冪等 tag 解析（retry-safe，upload 前先 list）
+
+Cloudflare 的 Worker version tag（`annotations["workers/tag"]`）**可重複使用，不保證唯一**；但本專案的 release ID 是 deterministic（同一 git SHA + 同一 client manifest digest ⇒同一 tag）。因此若對同一次 build 重跑 `deploy`/`deploy:staging`（例如上一輪在 phase 1 smoke 失敗後才重試），舊的已上傳 version 仍帶著相同 tag 留在 Cloudflare 帳號裡——若不先確認就再次 `upload`，會讓該 tag 從此永遠模糊（ambiguous），後續任何 `findVersionByTag` 查詢都會失敗且無法自動復原。故 `release-deploy.mjs` 在任何 mutating 呼叫之前，先 `versions list` 查一次目前 tag 狀態：
+
+- **0 筆符合**：正常路徑，`upload` 一次，再用既有的 upload-vs-list 交叉確認（見 5.2 第 3 點）。
+- **恰好 1 筆符合**：直接重用該 UUID，**不再重複 upload**，記錄 `VERSION_STATUS.REUSED`；接著比對是否已等於目前唯一 100% 的 old version：
+  - **相等**（即該 tag 已經是線上唯一版本——例如上一輪 finalize + final smoke 其實已成功，只是流程本身在回傳前中斷）：不做任何 mutating 呼叫，僅對 manifest routes 做一次 bounded 的 no-override final smoke 確認健康，通過後即回傳冪等成功（並照常寫入 finalized state；staging 額外 refresh shared approval），失敗則直接拋錯、不宣稱成功。
+  - **不相等**（該 UUID 是先前失敗 run 遺留、已被踢出 deployment 但未刪除的 version）：照常往下走 new0/old100 → smoke → promote → probe → finalize 全流程，只是跳過 upload 這一步。
+- **>1 筆符合**：在任何 mutating 呼叫之前 fail closed，錯誤訊息列出全部衝突 UUID，絕不猜測選哪一個——依 [`docs/superpowers/recovery.md`](../docs/superpowers/recovery.md) 人工診斷。
+
 ### 5.2 Phase 1：upload、new0 / old100、override smoke
 
 1. `vp run build` 產生 `dist/client` 與 generated config；它不會計算 release manifest，也不會發布 R2。

--- a/scripts/lib/deployment-state.mjs
+++ b/scripts/lib/deployment-state.mjs
@@ -73,6 +73,7 @@ export const DEFAULT_BASE_DIR = ".wrangler/releases";
 
 /** Controlled vocabulary for `VersionHistoryEntry.status`. */
 export const VERSION_STATUS = Object.freeze({
+  REUSED: "reused",
   UPLOADED: "uploaded",
   CONFIRM_FAILED: "confirm-failed",
   SMOKE_FAILED: "smoke-failed",

--- a/scripts/lib/wrangler-versions.mjs
+++ b/scripts/lib/wrangler-versions.mjs
@@ -275,21 +275,36 @@ export async function listVersions(configPath, workerName, opts = {}) {
 }
 
 /**
- * Resolve the version UUID whose `annotations["workers/tag"]` equals `tag`.
- * Used to independently confirm the UUID parsed from `versions upload`'s
- * text output against the authoritative `--json` listing.
+ * Return every version entry whose `annotations["workers/tag"]` equals
+ * `tag`, without requiring uniqueness. Deterministic release IDs mean a
+ * retry (after a partial prior run, or a concurrent duplicate upload) can
+ * legitimately find 0, 1, or >1 matches — callers decide how to react
+ * (reuse a unique match, fail closed on ambiguity, or upload when absent).
+ * @param {Array<Record<string, unknown>>} versions
+ * @param {string} tag
+ * @returns {Array<Record<string, unknown>>}
+ */
+export function findVersionsByTag(versions, tag) {
+  if (!Array.isArray(versions)) {
+    throw new Error("findVersionsByTag: versions must be an array");
+  }
+  return versions.filter((v) => {
+    const annotations = /** @type {Record<string, unknown> | undefined} */ (v?.annotations);
+    return annotations?.["workers/tag"] === tag;
+  });
+}
+
+/**
+ * Resolve the version UUID whose `annotations["workers/tag"]` equals `tag`,
+ * requiring EXACTLY one match. Used to independently confirm the UUID
+ * parsed from `versions upload`'s text output against the authoritative
+ * `--json` listing.
  * @param {Array<Record<string, unknown>>} versions
  * @param {string} tag
  * @returns {string}
  */
 export function findVersionByTag(versions, tag) {
-  if (!Array.isArray(versions)) {
-    throw new Error("findVersionByTag: versions must be an array");
-  }
-  const matches = versions.filter((v) => {
-    const annotations = /** @type {Record<string, unknown> | undefined} */ (v?.annotations);
-    return annotations?.["workers/tag"] === tag;
-  });
+  const matches = findVersionsByTag(versions, tag);
   if (matches.length === 0) {
     throw new Error(`No version found with tag ${tag}`);
   }

--- a/scripts/release-deploy.mjs
+++ b/scripts/release-deploy.mjs
@@ -4,9 +4,17 @@
  * Usage: node scripts/release-deploy.mjs  (CLOUDFLARE_ENV=staging|production, default production)
  *
  * Runs the full safe protocol: prod approval gate → require old@100 →
- * upload tagged version → deploy new@0/old@100 → version-override smoke →
- * promote new@100/old@0 → 120s continuous probe → finalize new@100 alone →
- * final smoke → save state → (staging only) record approval for prod.
+ * resolve tagged version idempotently (reuse an existing match, upload only
+ * when none exists, fail closed before any mutation on ambiguity, and
+ * short-circuit to idempotent success with no mutation at all when the
+ * resolved version is already the sole live version) → deploy new@0/old@100
+ * → version-override smoke → promote new@100/old@0 → 120s continuous probe
+ * → finalize new@100 alone → final smoke → save state → (staging only)
+ * record approval for prod. Release IDs are deterministic (git SHA +
+ * client manifest digest), so retrying the exact same build after any
+ * partial prior run must never blindly re-upload — Cloudflare version tags
+ * are reusable, not unique, so a duplicate upload would make the tag
+ * permanently ambiguous.
  *
  * `runReleaseDeploy` is the fully dependency-injected, unit-testable core.
  * `main()` supplies real adapters (process env, real Wrangler subprocess,
@@ -34,6 +42,8 @@ import {
   rollbackToVersion,
   listVersions,
   findVersionByTag,
+  findVersionsByTag,
+  validateVersionUuid,
   getCurrentDeployment,
   requireSingleVersion100,
 } from "./lib/wrangler-versions.mjs";
@@ -197,35 +207,102 @@ export async function runReleaseDeploy(opts = {}) {
   const oldDeployment = await getCurrentDeployment(configPath, workerName, { runner });
   const oldVersionUuid = requireSingleVersion100(oldDeployment);
 
-  // 5. Upload the new tagged version (first mutating call), confirmed via versions list.
-  const uploadedUuid = await uploadVersion(configPath, releaseId, { runner });
-  const versions = await listVersions(configPath, workerName, { runner });
-  const confirmedUuid = findVersionByTag(versions, releaseId);
-  if (confirmedUuid !== uploadedUuid) {
+  // 5. Resolve the tagged version idempotently. Release IDs are
+  //    deterministic (same git SHA + client manifest digest -> same tag),
+  //    so a retry after any prior partial run (upload succeeded but a
+  //    later phase failed and left the version unfinalized, or the whole
+  //    process crashed right after upload) must reuse the existing tagged
+  //    version rather than blindly uploading again — Cloudflare tags are
+  //    not unique, so a second upload with the same tag would make every
+  //    future lookup permanently ambiguous. List BEFORE uploading.
+  const preUploadVersions = await listVersions(configPath, workerName, { runner });
+  const preMatches = findVersionsByTag(preUploadVersions, releaseId);
+  let newVersionUuid;
+  if (preMatches.length > 1) {
+    const ids = preMatches.map((v) => /** @type {{ id: unknown }} */ (v).id).join(", ");
+    throw new Error(
+      `Ambiguous: ${preMatches.length} existing versions already carry tag ${releaseId} (${ids}) — ` +
+        `refusing to pick one before any mutating call; investigate manually (see docs/superpowers/recovery.md)`,
+    );
+  } else if (preMatches.length === 1) {
+    const reusedId = /** @type {{ id: unknown }} */ (preMatches[0]).id;
+    validateVersionUuid(/** @type {string} */ (reusedId));
+    newVersionUuid = /** @type {string} */ (reusedId);
     saveVersionEntry(
       {
-        versionId: uploadedUuid,
+        versionId: newVersionUuid,
         tag: releaseId,
         uploadedAt: nowIso(),
-        status: VERSION_STATUS.CONFIRM_FAILED,
+        status: VERSION_STATUS.REUSED,
       },
       stateOpts,
     );
-    throw new Error(
-      `Version UUID mismatch: upload output reported ${uploadedUuid}, but versions list confirms ` +
-        `${confirmedUuid} for tag ${releaseId}`,
+  } else {
+    const uploadedUuid = await uploadVersion(configPath, releaseId, { runner });
+    const versions = await listVersions(configPath, workerName, { runner });
+    const confirmedUuid = findVersionByTag(versions, releaseId);
+    if (confirmedUuid !== uploadedUuid) {
+      saveVersionEntry(
+        {
+          versionId: uploadedUuid,
+          tag: releaseId,
+          uploadedAt: nowIso(),
+          status: VERSION_STATUS.CONFIRM_FAILED,
+        },
+        stateOpts,
+      );
+      throw new Error(
+        `Version UUID mismatch: upload output reported ${uploadedUuid}, but versions list confirms ` +
+          `${confirmedUuid} for tag ${releaseId}`,
+      );
+    }
+    newVersionUuid = confirmedUuid;
+    saveVersionEntry(
+      {
+        versionId: newVersionUuid,
+        tag: releaseId,
+        uploadedAt: nowIso(),
+        status: VERSION_STATUS.UPLOADED,
+      },
+      stateOpts,
     );
   }
-  const newVersionUuid = confirmedUuid;
-  saveVersionEntry(
-    {
+
+  // 5b. Idempotency short-circuit: the resolved version is already the
+  //     sole live version (e.g. a prior run's finalize + final smoke
+  //     already succeeded and only the process/CLI exited before
+  //     returning). Re-confirm health with a bounded, no-override final
+  //     smoke against the manifest routes and return success WITHOUT any
+  //     further mutating Wrangler call — never re-run a rollout against a
+  //     version that is already correctly serving 100% of traffic.
+  if (newVersionUuid === oldVersionUuid) {
+    await finalSmoke(baseUrl, routes, releaseId, { fetch: fetchImpl, ...probeTimeoutOpts });
+    const deployedAt = nowIso();
+    saveVersionEntry(
+      {
+        versionId: newVersionUuid,
+        tag: releaseId,
+        uploadedAt: deployedAt,
+        status: VERSION_STATUS.FINALIZED,
+      },
+      stateOpts,
+    );
+    saveCurrentDeployment(
+      { workerName, versionId: newVersionUuid, tag: releaseId, percentage: 100, deployedAt },
+      stateOpts,
+    );
+    if (env === "staging") {
+      saveStagingApproval({ gitSha, clientManifestDigest, approvedAt: deployedAt }, approvalOpts);
+    }
+    return {
+      releaseId,
+      workerName,
       versionId: newVersionUuid,
-      tag: releaseId,
-      uploadedAt: nowIso(),
-      status: VERSION_STATUS.UPLOADED,
-    },
-    stateOpts,
-  );
+      env,
+      deployedAt,
+      alreadyCurrent: true,
+    };
+  }
 
   // 6. Deploy new@0 / old@100.
   await deployVersionSplit(

--- a/tests/unit/release-deploy.test.ts
+++ b/tests/unit/release-deploy.test.ts
@@ -107,6 +107,7 @@ function buildRunner(
   onCall?: (phase: string, argv: string[]) => void,
 ) {
   const calls: string[][] = [];
+  let versionsListCalls = 0;
   const runner = async (argv: string[]) => {
     calls.push(argv);
     const phase = phaseOf(argv);
@@ -114,6 +115,18 @@ function buildRunner(
     const override = overrides[phase];
     if (override) {
       return typeof override === "function" ? override(argv, calls.length) : override;
+    }
+    if (phase === "versions-list") {
+      versionsListCalls += 1;
+      // Default (no override): the FIRST versions-list call is always the
+      // orchestrator's pre-upload existence check (step 5) and, by
+      // default, finds nothing tagged yet — the common "fresh release, no
+      // prior upload" case every unmodified test below represents. Any
+      // LATER call is the post-upload confirm and finds the freshly
+      // uploaded version, matching the pre-existing fixture.
+      return versionsListCalls === 1
+        ? { exitCode: 0, stdout: "[]", stderr: "" }
+        : DEFAULT_RESPONSES["versions-list"];
     }
     const fallback = DEFAULT_RESPONSES[phase];
     if (!fallback) throw new Error(`unmocked wrangler phase: ${phase} (argv: ${argv.join(" ")})`);
@@ -384,11 +397,23 @@ describe("requires a safe old version before starting", () => {
 });
 describe("upload confirmation (upload UUID vs versions-list tag lookup)", () => {
   it("aborts before any deploy call when the uploaded UUID mismatches the unique versions-list tag match", async () => {
+    // Pre-upload existence check (call 1) finds nothing tagged yet; the
+    // post-upload confirm (call 2) disagrees with what `upload` itself
+    // reported — this is the CLI's own text-vs-JSON cross-check, distinct
+    // from the idempotent-reuse path exercised below.
+    let versionsListCall = 0;
     const { runner, calls } = buildRunner({
-      "versions-list": {
-        exitCode: 0,
-        stdout: JSON.stringify([{ id: OTHER_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
-        stderr: "",
+      "versions-list": () => {
+        versionsListCall += 1;
+        return versionsListCall === 1
+          ? { exitCode: 0, stdout: "[]", stderr: "" }
+          : {
+              exitCode: 0,
+              stdout: JSON.stringify([
+                { id: OTHER_UUID, annotations: { "workers/tag": RELEASE_ID } },
+              ]),
+              stderr: "",
+            };
       },
     });
     const { fetchImpl } = buildFetch();
@@ -416,6 +441,225 @@ describe("upload confirmation (upload UUID vs versions-list tag lookup)", () => 
     });
     // Never claims success: no current-deployment state exists.
     expect(readCurrentDeployment({ baseDir: join(dir, "staging") })).toBeNull();
+  });
+});
+
+// ── idempotent tag resolution (retry-safe: deterministic release IDs) ──
+//
+// Cloudflare version tags are reusable, not unique. Since the release ID
+// is deterministic (same git SHA + client manifest digest -> same tag),
+// retrying the exact same build after ANY prior partial run must reuse an
+// already-uploaded version instead of uploading a duplicate — a second
+// upload with the same tag would make every future lookup permanently
+// ambiguous. These tests exercise the list-before-upload resolution added
+// to step 5, independent of the pre-existing post-upload confirm checked
+// above.
+describe("idempotent tag resolution", () => {
+  it("retry after a prior upload (no finalize yet): reuses the existing tagged version, never re-uploads, proceeds through new0/old100 normally", async () => {
+    const { runner, calls } = buildRunner({
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([{ id: NEW_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl } = buildFetch();
+    const result = await runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl }));
+    expect(result.versionId).toBe(NEW_UUID);
+    expect(calls.some((c) => c.includes("upload"))).toBe(false);
+    const phase1 = calls.find((c) => phaseOf(c) === "deploy-phase1");
+    expect(phase1).toContain(`${NEW_UUID}@0%`);
+    expect(phase1).toContain(`${OLD_UUID}@100%`);
+    const history = readVersionHistory({ baseDir: join(dir, "staging") });
+    expect(history[0]).toMatchObject({
+      versionId: NEW_UUID,
+      tag: RELEASE_ID,
+      status: VERSION_STATUS.REUSED,
+    });
+  });
+
+  it("retry after a phase-1 smoke failure: the abandoned uploaded version (rolled out of the deployment but never deleted) is found and reused, not re-uploaded", async () => {
+    // Simulates a second `runReleaseDeploy` invocation after a prior run's
+    // override smoke failed and restored old@100 alone: the current
+    // deployment is back to a clean old@100 (from step 4's perspective),
+    // but `versions list` still carries the abandoned NEW_UUID upload.
+    const { runner, calls } = buildRunner({
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([{ id: NEW_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl } = buildFetch();
+    await runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl }));
+    expect(calls.some((c) => c.includes("upload"))).toBe(false);
+    expect(calls.some((c) => phaseOf(c) === "deploy-promote")).toBe(true);
+    expect(calls.some((c) => phaseOf(c) === "finalize")).toBe(true);
+  });
+
+  it("current-already-release idempotency: when the sole matching tagged version is already live at 100%, returns success with zero mutating calls beyond the read-only pre-check", async () => {
+    const { runner, calls } = buildRunner({
+      // OLD_UUID (already the sole live version per the default
+      // deployments-list fixture) is ALSO the version carrying this
+      // release's tag — e.g. a CLI retry after finalize + final smoke
+      // already succeeded but the process exited before returning.
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([{ id: OLD_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl, calls: fetchCalls } = buildFetch();
+    const result = await runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl }));
+    expect(result).toMatchObject({ versionId: OLD_UUID, alreadyCurrent: true });
+    // No mutating call at all: only the read-only deployments-list and
+    // versions-list queries, plus the bounded no-override final smoke.
+    const mutatingPhases: Record<string, true> = {
+      upload: true,
+      "deploy-phase1": true,
+      "deploy-promote": true,
+      "deploy-rollback": true,
+      "restore-old-alone": true,
+      finalize: true,
+    };
+    expect(calls.some((c) => mutatingPhases[phaseOf(c)])).toBe(false);
+    // The bounded final smoke ran WITHOUT the override header.
+    expect(fetchCalls.length).toBeGreaterThan(0);
+    expect(fetchCalls.every((c) => c.override === undefined)).toBe(true);
+    const current = readCurrentDeployment({ baseDir: join(dir, "staging") });
+    expect(current?.versionId).toBe(OLD_UUID);
+    expect(current?.percentage).toBe(100);
+  });
+
+  it("current-already-release idempotency also refreshes staging approval so production's gate sees a fresh approvedAt", async () => {
+    const { runner } = buildRunner({
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([{ id: OLD_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl } = buildFetch();
+    const result = await runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl }));
+    const approval = readStagingApproval({ baseDir: dir });
+    expect(approval).toEqual({
+      gitSha: GIT_SHA,
+      clientManifestDigest: DIGEST,
+      approvedAt: result.deployedAt,
+    });
+  });
+
+  it("current-already-release idempotency for PRODUCTION: passes the approval gate, short-circuits with zero mutation, and never writes a staging approval", async () => {
+    saveStagingApproval(
+      { gitSha: GIT_SHA, clientManifestDigest: DIGEST, approvedAt: "2026-07-12T00:00:00Z" },
+      { baseDir: dir },
+    );
+    const { runner, calls } = buildRunner({
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([{ id: OLD_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl } = buildFetch();
+    const result = await runReleaseDeploy(baseOpts("production", { runner, fetch: fetchImpl }));
+    expect(result).toMatchObject({ versionId: OLD_UUID, alreadyCurrent: true, env: "production" });
+    const mutatingPhases: Record<string, true> = {
+      upload: true,
+      "deploy-phase1": true,
+      "deploy-promote": true,
+      "deploy-rollback": true,
+      "restore-old-alone": true,
+      finalize: true,
+    };
+    expect(calls.some((c) => mutatingPhases[phaseOf(c)])).toBe(false);
+    // Production idempotent short-circuit never writes a staging approval —
+    // the pre-seeded one is left byte-for-byte unchanged.
+    expect(readStagingApproval({ baseDir: dir })).toEqual({
+      gitSha: GIT_SHA,
+      clientManifestDigest: DIGEST,
+      approvedAt: "2026-07-12T00:00:00Z",
+    });
+    const current = readCurrentDeployment({ baseDir: join(dir, "production") });
+    expect(current?.versionId).toBe(OLD_UUID);
+    expect(current?.percentage).toBe(100);
+  });
+
+  it("current-already-release idempotency still rolls back to nothing (throws, no false success) when the bounded final smoke fails", async () => {
+    const { runner } = buildRunner({
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([{ id: OLD_UUID, annotations: { "workers/tag": RELEASE_ID } }]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl } = buildFetch(() => new Response("err", { status: 500 }));
+    await expect(
+      runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl })),
+    ).rejects.toThrow();
+    expect(readCurrentDeployment({ baseDir: join(dir, "staging") })).toBeNull();
+  });
+
+  it("ambiguity before mutation: multiple existing versions already carry the release tag before any upload — fails closed, names both UUIDs, never mutates", async () => {
+    const { runner, calls } = buildRunner({
+      "versions-list": {
+        exitCode: 0,
+        stdout: JSON.stringify([
+          { id: NEW_UUID, annotations: { "workers/tag": RELEASE_ID } },
+          { id: OTHER_UUID, annotations: { "workers/tag": RELEASE_ID } },
+        ]),
+        stderr: "",
+      },
+    });
+    const { fetchImpl } = buildFetch();
+    await expect(
+      runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl })),
+    ).rejects.toThrow(new RegExp(`Ambiguous.*${NEW_UUID}.*${OTHER_UUID}`, "s"));
+    // Zero mutating calls: not even `upload` fired, since ambiguity is
+    // detected strictly before any mutation.
+    const mutatingPhases: Record<string, true> = {
+      upload: true,
+      "deploy-phase1": true,
+      "deploy-promote": true,
+      "deploy-rollback": true,
+      "restore-old-alone": true,
+      finalize: true,
+    };
+    expect(calls.some((c) => mutatingPhases[phaseOf(c)])).toBe(false);
+    expect(readVersionHistory({ baseDir: join(dir, "staging") })).toHaveLength(0);
+    expect(readCurrentDeployment({ baseDir: join(dir, "staging") })).toBeNull();
+  });
+
+  it("race duplicate after upload: a concurrent run tags a second version between this run's pre-check and its own upload — the post-upload confirm still catches the now-ambiguous tag and aborts before any deploy call", async () => {
+    let versionsListCall = 0;
+    const { runner, calls } = buildRunner({
+      "versions-list": () => {
+        versionsListCall += 1;
+        return versionsListCall === 1
+          ? { exitCode: 0, stdout: "[]", stderr: "" } // pre-check: still clear
+          : {
+              // post-upload confirm: a concurrent run's upload landed too
+              exitCode: 0,
+              stdout: JSON.stringify([
+                { id: NEW_UUID, annotations: { "workers/tag": RELEASE_ID } },
+                { id: OTHER_UUID, annotations: { "workers/tag": RELEASE_ID } },
+              ]),
+              stderr: "",
+            };
+      },
+    });
+    const { fetchImpl } = buildFetch();
+    await expect(
+      runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl })),
+    ).rejects.toThrow(/Ambiguous: 2 versions found with tag/);
+    const mutatingPhases: Record<string, true> = {
+      "deploy-phase1": true,
+      "deploy-promote": true,
+      "deploy-rollback": true,
+      "restore-old-alone": true,
+      finalize: true,
+    };
+    expect(calls.some((c) => mutatingPhases[phaseOf(c)])).toBe(false);
   });
 });
 
@@ -666,7 +910,7 @@ describe("fails clearly when Task 2 build output is absent", () => {
 // ── malformed CLI JSON / runner failure propagation ───────────────────
 
 describe("malformed CLI output and runner failures", () => {
-  it("propagates malformed versions-list JSON from the confirm-tag step", async () => {
+  it("propagates malformed versions-list JSON (fires on the pre-upload existence check, the first call to this phase)", async () => {
     const { runner } = buildRunner({
       "versions-list": { exitCode: 0, stdout: "not json", stderr: "" },
     });
@@ -789,6 +1033,7 @@ it("executes phases in the exact required order for a full success run", async (
   await runReleaseDeploy(baseOpts("staging", { runner, fetch: fetchImpl }));
   expect(timeline).toEqual([
     "runner:deployments-list",
+    "runner:versions-list",
     "runner:upload",
     "runner:versions-list",
     "runner:deploy-phase1",

--- a/tests/unit/wrangler-versions.test.ts
+++ b/tests/unit/wrangler-versions.test.ts
@@ -15,6 +15,7 @@ import {
   deployVersionSplit,
   findTagByVersionId,
   findVersionByTag,
+  findVersionsByTag,
   getCurrentDeployment,
   listVersions,
   requireSingleVersion100,
@@ -317,6 +318,36 @@ describe("findVersionByTag", () => {
       { id: NEW_UUID, annotations: { "workers/tag": TAG } },
     ];
     expect(() => findVersionByTag(versions, TAG)).toThrow(/Ambiguous/);
+  });
+});
+
+describe("findVersionsByTag", () => {
+  it("returns all matching version entries without requiring uniqueness", () => {
+    const versions = [
+      { id: OLD_UUID, annotations: { "workers/tag": TAG } },
+      { id: NEW_UUID, annotations: { "workers/tag": TAG } },
+      { id: "33333333-3333-4333-8333-333333333333", annotations: { "workers/tag": "other" } },
+    ];
+    expect(findVersionsByTag(versions, TAG)).toEqual([
+      { id: OLD_UUID, annotations: { "workers/tag": TAG } },
+      { id: NEW_UUID, annotations: { "workers/tag": TAG } },
+    ]);
+  });
+
+  it("returns an empty array when nothing matches (not an error — callers decide)", () => {
+    expect(findVersionsByTag([{ id: OLD_UUID, annotations: {} }], TAG)).toEqual([]);
+  });
+
+  it("returns an empty array for an empty versions list", () => {
+    expect(findVersionsByTag([], TAG)).toEqual([]);
+  });
+
+  it("throws when versions is not an array", () => {
+    expect(() => findVersionsByTag(null as never, TAG)).toThrow(/must be an array/);
+  });
+
+  it("treats a version with no annotations as non-matching, not a crash", () => {
+    expect(findVersionsByTag([{ id: OLD_UUID }], TAG)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Context

Immediate follow-up to #140 (merged, `e737569`). Before any real Cloudflare
shipment ran, an independent final pre-ship adversarial review (internal
audit, not a GitHub review — see below) identified a genuine correctness gap
in the retry path of the two-phase deployment orchestrator, confirmed by the
repo owner as a concrete pre-ship blocker. Production/staging shipment is
held at **zero Cloudflare mutations** until this merges and is verified green.

## Root cause

Cloudflare Worker version tags (`annotations["workers/tag"]`) are **reusable,
not unique** — but this project's release IDs are deterministic (same git SHA
+ same client manifest digest ⇒ same tag). `release-deploy.mjs` previously
called `wrangler versions upload --tag <release-id>` unconditionally on every
invocation. Retrying the exact same build after any prior partial run (a
phase-1 override-smoke failure that correctly restored `old@100` but left the
uploaded version un-deleted on Cloudflare's side, or a process crash right
after upload) would upload a **second** version carrying the identical tag.
From that point on, every `findVersionByTag` lookup (used both by the
post-upload confirm step and by emergency rollback tooling) throws
`Ambiguous: 2 versions found with tag ...` — the release becomes permanently
un-shippable through the standard path without manual Cloudflare-side
intervention.

## Fix

`scripts/release-deploy.mjs` now lists Worker versions **before** uploading
and resolves the tag idempotently:

- **0 matches** — uploads once, confirms via the pre-existing post-upload
  list + cross-check (unchanged), which itself still aborts before any
  mutating call if a concurrent run's duplicate upload races in between.
- **exactly 1 match** — reuses that UUID, records `VERSION_STATUS.REUSED`,
  **never re-uploads**.
  - If that UUID is already the sole live version at 100% (e.g. a prior
    run's finalize + final smoke actually succeeded but the process exited
    before returning), short-circuits to **idempotent success**: a single
    bounded, no-override final smoke against the manifest routes, zero
    mutating Wrangler calls, staging approval refreshed on staging, no
    approval write on production. A failing bounded smoke here still throws
    (no false success).
  - Otherwise (an abandoned upload from a failed prior run) proceeds through
    `new@0%/old@100%` → smoke → promote → probe → finalize exactly as before,
    just skipping the upload step.
- **>1 matches** — fails closed **before any mutating call**, naming every
  conflicting UUID in the error; never guesses.

`findVersionsByTag` (new, non-throwing, returns all matches) is the shared
primitive now underneath the pre-existing strict `findVersionByTag` (DRY, no
duplicate filter logic). `VERSION_STATUS.REUSED` is a new controlled-vocab
audit status alongside the existing ones.

Documented in `notes/零停機部署筆記.md` §5.1a (new).

## Tests

TDD: 8 new scenarios in `tests/unit/release-deploy.test.ts` —

- retry after a prior upload (no finalize yet): reuse, no re-upload
- retry after a phase-1 smoke failure: abandoned upload found and reused
- current-already-release idempotency (staging): zero mutation, bounded smoke
- current-already-release idempotency (production): passes the approval
  gate, zero mutation, never writes a staging approval
- idempotent short-circuit refreshes staging approval's `approvedAt`
- idempotent short-circuit still throws (no false success) when the bounded
  smoke fails
- ambiguity before mutation: >1 pre-existing match fails closed, zero calls
- race duplicate detected at post-upload confirm: a concurrent run's upload
  lands between this run's pre-check and its own upload; the pre-existing
  post-upload cross-check still catches it

Plus 5 new tests for `findVersionsByTag` in `tests/unit/wrangler-versions.test.ts`.

Verified in a clean worktree off merged `origin/main`:

- Focused release-orchestrator suite: 173/173 passing.
- `bun run test:coverage:release`: 100% statements / 100% functions / 100%
  lines / **96.28%** branches (unchanged ≥96% floor; the 3 newly-uncovered
  release-deploy.mjs lines are the same class of pre-existing default-arg/
  real-subprocess-default plumbing as the rest of the file, not new
  unexercised business logic).
- Full unit: 1534/1534 (54 files).
- Integration: 99/99 (8 files).
- E2E (chromium): 96/96.
- `vp run typecheck`, `vp check`, `vp node scripts/check-v8-ignore-count.mjs`
  (17/20, unchanged), `vp node scripts/check-deploy-scripts-safety.mjs`,
  `vp run check:data`, `vp run check:trs`, `vp run check:css-ids`,
  `vp run check:css-lint`, `vp run build`: all clean/exit 0.

No Cloudflare mutation performed by this change or its verification — every
test is dependency-injected against a mocked Wrangler runner and mocked
fetch, exactly like the rest of `release-deploy.mjs`'s existing test suite.

## Process note

Repo ruleset `protect-main` requires 1 approving PR review, but the only
authenticated GitHub identity available in this environment (`audreyt`) is
also this PR's author, making GitHub self-approval structurally impossible.
As with #140, this will be merged via repository-admin bypass
(`current_user_can_bypass=always` for `OrganizationAdmin` per the ruleset)
once required CI checks are green, substituting the adversarial review that
already caught this exact issue pre-merge as the effective review gate.
