### PR TITLE
fix: wait for edge propagation after every versions deploy

### DIFF
--- a/scripts/release-deploy.mjs
+++ b/scripts/release-deploy.mjs
@@ -149,9 +149,11 @@ export async function runReleaseDeploy(opts = {}) {
   const nowIso = opts.nowIso ?? (() => new Date().toISOString());
   const soakIntervalMs = opts.soakIntervalMs ?? 5000;
   const soakDurationMs = opts.soakDurationMs ?? 120000;
-  // 10s default: Cloudflare documents a brief global propagation window
-  // after versions deploy before override routing is reliable everywhere.
-  const propagationSleepMs = opts.propagationSleepMs ?? 10000;
+  // 30s default: Cloudflare's edge propagation for versions deploy can take
+  // longer than documented ("a couple of seconds") in practice — empirically
+  // observed failures at 10s on a real workers.dev worker (3 consecutive runs,
+  // zero failures once increased). Injectable; set to 0 to skip in tests.
+  const propagationSleepMs = opts.propagationSleepMs ?? 30000;
   const sleepImpl =
     opts.sleep /* v8 ignore next -- real sleep; not exercised in unit tests */ ??
     ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
@@ -324,7 +326,7 @@ export async function runReleaseDeploy(opts = {}) {
   // 6b. Wait for global edge propagation before probing with version override.
   //     Cloudflare documents a brief propagation window after `versions deploy`
   //     before the override header reliably routes to the new version on all
-  //     edges. Default 10s; injectable for tests (set to 0 to skip).
+  //     edges. Default 30s; injectable for tests (set to 0 to skip).
   if (propagationSleepMs > 0) await sleepImpl(propagationSleepMs);
   // 7. Smoke the new version at 0% via version override. On failure, restore
   //    old@100 ALONE (not new@0/old@100) so the next run is not poisoned.
@@ -366,6 +368,12 @@ export async function runReleaseDeploy(opts = {}) {
     ],
     { runner },
   );
+  // 8b. Wait for the 100% traffic switch to propagate before continuous probing.
+  //     Same edge lag as step 6b: without this, cycle-1 of continuousProbe can
+  //     still hit a PoP on the pre-promote deployment and false-fail on missing
+  //     X-Moedict-Release (observed 2026-07-12: override smoke green, promote
+  //     green, continuousProbe cycle 1 failed with got null).
+  if (propagationSleepMs > 0) await sleepImpl(propagationSleepMs);
   saveVersionEntry(
     {
       versionId: newVersionUuid,
@@ -420,6 +428,8 @@ export async function runReleaseDeploy(opts = {}) {
   } catch (finalizeErr) {
     await rollbackOnFailure(finalizeErr);
   }
+  // 10b. Wait for finalize (collapse to single-version deployment) to propagate.
+  if (propagationSleepMs > 0) await sleepImpl(propagationSleepMs);
 
   // 11. Final smoke — no override header, but still requires the release ID header.
   try {

--- a/tests/unit/release-deploy.test.ts
+++ b/tests/unit/release-deploy.test.ts
@@ -830,7 +830,7 @@ it("soaks for at least 120s by default (24 sleeps of 5000ms) when soak options a
   expect(sleepCalls.every((ms) => ms === 5000)).toBe(true);
 });
 
-it("sleeps propagationSleepMs (default 10s) between deploy-phase1 and the version-override smoke probe", async () => {
+it("sleeps propagationSleepMs (default 30s) after each versions-deploy before the next probe phase", async () => {
   const timeline: string[] = [];
   const { runner } = buildRunner({}, (phase) => timeline.push(`runner:${phase}`));
   const { fetchImpl } = buildFetch(({ override }) => {
@@ -845,17 +845,15 @@ it("sleeps propagationSleepMs (default 10s) between deploy-phase1 and the versio
       sleepCalls.push(ms);
     },
   });
-  // The first sleep call must be the propagation delay, before any override fetch.
-  expect(sleepCalls[0]).toBe(7000);
+  // Three propagation sleeps: after phase1, after promote, after finalize.
+  // Interleaved with soak sleeps (soakIntervalMs=1 from baseOpts → one 1ms sleep).
+  expect(sleepCalls.filter((ms) => ms === 7000)).toHaveLength(3);
+  expect(sleepCalls[0]).toBe(7000); // first is always post-phase1, before override smoke
   const firstOverrideFetch = timeline.indexOf("fetch:override");
-  const firstSleep = timeline.length; // sleepCalls are not tracked in timeline, but deploy-phase1 must precede the smoke
-  // Verify deploy-phase1 fires BEFORE any override probe.
   expect(timeline.indexOf("runner:deploy-phase1")).toBeLessThan(firstOverrideFetch);
-  // Verify the propagation sleep fires (sleepCalls[0] is 7000, not a soak value).
-  expect(sleepCalls).toContain(7000);
-  // The remaining calls are soak sleeps driven by soakIntervalMs (set to 1 in baseOpts).
-  expect(sleepCalls.slice(1).every((ms) => ms === 1)).toBe(true);
-  void firstSleep; // suppress unused warning
+  // Soak sleeps remain the short interval, not the propagation value.
+  expect(sleepCalls.some((ms) => ms === 1)).toBe(true);
+  expect(sleepCalls.every((ms) => ms === 7000 || ms === 1)).toBe(true);
 });
 
 // ── state persistence ──────────────────────────────────────────────


### PR DESCRIPTION
Empirically confirmed during first real staging shipment that Cloudflare edge lag after versions deploy reappears at every phase boundary. Default propagationSleepMs is now 30s and applied after phase1, promote, and finalize. Staging shipped: release 8fc64f2-5db141ad4cd4 version b5d0fc27-7372-4607-8232-d07abe6c3a3b. 