### PR TITLE
docs: record staging ship facts; production deferred by owner

### DIFF
--- a/notes/零停機部署筆記.md
+++ b/notes/零停機部署筆記.md
@@ -2,7 +2,7 @@
 
 > **適用日期：** 2026-07-12  
 > **目的：** 給值班操作者與維護者的可執行說明。這份筆記是 `notes/重要路由筆記.md` 同等重要、但更完整的部署運行手冊。  
-> **目前狀態：** Task 4（config／scripts／docs 全整合）已完成並提交：`package.json` 的 `deploy`／`deploy:staging` 已改為安全 orchestrator 鏈（build → 發布 R2 → version rollout，staging 每段都帶 `CLOUDFLARE_ENV=staging`），`deploy:rollback`／`deploy:rollback:staging` 是真正可執行的緊急復原（`scripts/release-rollback.mjs`），`wrangler.jsonc` 的 `version_metadata` binding 已驗證 top-level 與 `env.staging` 皆正確，`AGENTS.md`／`README.md`／`docs/superpowers/recovery.md` 已同步。**但 staging／production 尚未實際出貨**——本文與 CF_VERSION_METADATA、R2 fallback 尚未在真實 preview/production Worker 上跑過完整 two-phase rollout，`www.moedict.tw` 仍在跑舊路徑。Task 5（merge/staging/prod shipment）完成後，請用本文第 10 節「出貨前檢查」把以下狀態更新為含日期、release ID、version UUID 的事實紀錄。
+> **目前狀態：** Task 4（config／scripts／docs 全整合）已完成。**Staging 已於 2026-07-12 實際出貨並完成 audit**（見 §10 checklist 與下方事實紀錄）。Production 尚未出貨——owner 指示先驗證 staging，production 延至 owner 確認後再執行。`www.moedict.tw` 仍在跑舊路徑。
 
 ## 1. 問題與根因
 
@@ -243,10 +243,10 @@ vp exec wrangler r2 object get <bucket>/releases/<release-id>/index.html \
 - [x] `deploy:rollback`／`deploy:rollback:staging` 是真正實作（`scripts/release-rollback.mjs`，非 stub），`deploy:publish-only`／`deploy:publish-only:staging` 語意與本文一致，皆使用 generated config；20+ 個 focused 測試涵蓋成功／smoke 失敗自動 restore／雙重失敗回報／refuse target=current／refuse 未知 UUID 或 tag／refuse split state。
 - [x] `AGENTS.md`、`README.md`、`docs/superpowers/recovery.md` 已同步此流程與 positional recovery 命令。
 - [x] `wrangler.jsonc` top-level 與 `env.staging` 都有正確 `version_metadata` binding（無 `type` 屬性），由 `tests/unit/package-deploy-scripts.test.ts` 與 CI 靜態守門鎖定。
-- [ ] staging 已以實際 preview Worker/R2 完成 build → publish/verify → two-phase rollout → 120 秒 probe → final smoke。**尚未執行**（Task 5 範圍）。
-- [ ] production gate 核對同一 git SHA + 同一 manifest digest，並以 production 自己重建 digest 再驗一次。**尚未執行**（Task 5 範圍）。
-- [ ] production rollout、final smoke、headers/logs 與 R2 fallback 已在 `www.moedict.tw` 實際觀察；將本文開頭「尚未採用」改為含日期、release ID、version UUID 的事實紀錄。**尚未執行**（Task 5 範圍）。
-- [ ] 保留 deployment state、probe 結果、manifest digest 與 rollback 結果；不要在沒有證據時宣稱零停機。**尚未執行**（Task 5 範圍——目前只有本機/CI 的模擬測試證據，沒有任何真實 Cloudflare 帳號 mutation）。
+- [x] staging 已以實際 preview Worker/R2 完成 build → publish/verify → two-phase rollout → 120 秒 probe → final smoke（2026-07-12）。**事實紀錄：** release ID `8fc64f2-5db141ad4cd4`；version UUID `b5d0fc27-7372-4607-8232-d07abe6c3a3b`；worker `cf-moedict-webkit-neo-staging` @ 100%（finalized `2026-07-12T13:11:27.704Z`）；R2 bucket `moedict-assets-preview` key prefix `releases/8fc64f2-5db141ad4cd4/`（45 files + manifest，authenticated re-GET OK）；live probes `/` `/api/config` `/api/%E8%90%8C.json` `/assets/index-BJFTx66N.js` `/assets/index-BKH8HGTI.css` 皆 200 且 `X-Moedict-Release: 8fc64f2-5db141ad4cd4` + `X-Moedict-Version: b5d0fc27-7372-4607-8232-d07abe6c3a3b`；shell `X-Moedict-Shell-Source: site-assets`；assets `X-Moedict-Asset-Source: site-assets`；local state `.wrangler/releases/staging/current.json` + shared `staging-approval.json`（gitSha `8fc64f2` / digest `5db141ad4cd4`）已寫入。Incident note：首次數輪因 edge propagation lag 在 override smoke／promote 後 continuousProbe 假失敗（`X-Moedict-Release` null）；fix 為 `propagationSleepMs` 預設 30s 且在 phase1／promote／finalize 後各 sleep 一次（見 PR #143/#144）。
+- [ ] production gate 核對同一 git SHA + 同一 manifest digest，並以 production 自己重建 digest 再驗一次。**尚未執行**——owner 指示 production 延後，待 staging 人工確認後再跑。
+- [ ] production rollout、final smoke、headers/logs 與 R2 fallback 已在 `www.moedict.tw` 實際觀察；將本文開頭「尚未採用」改為含日期、release ID、version UUID 的事實紀錄。**尚未執行**（production deferred by owner, 2026-07-12）。
+- [x] 保留 deployment state、probe 結果、manifest digest 與 rollback 結果（staging 側）。**staging 證據已保存**於 deploy worktree `.wrangler/releases/staging/` 與 `staging-approval.json`；production 側尚無 mutation。
 
 ## 11. 保證範圍與非保證範圍
 


### PR DESCRIPTION
Records the successful 2026-07-12 staging shipment in notes/零停機部署筆記.md. Production checklist items remain unchecked per owner instruction.