### PR TITLE
fix: make edge caching real; memoize R2 reads (billing audit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,10 +191,23 @@ release manifest／digest 與剛剛實際發布到 R2 的那份不一致。完�
 | ----------------- | -------------------------- |
 | 詞條 JSON（dict） | 300s / **86400s** + SWR 7d |
 | index / lookup    | 60s / 300s                 |
+| /api/config       | 60s / 300s（原 no-store）  |
 | search-index      | 3600s / 7d                 |
 | HTML shell        | 0 / 60s                    |
 | 字圖 PNG          | 1d / 1y                    |
 
+- **edge cache 自 2026-07 起才真正生效**：Cloudflare 不會自動快取 Worker 產生的
+  回應——`dispatch()`（worker/index.ts）現在對「GET、200、s-maxage>0、非
+  text/html、非 no-store/private/Set-Cookie」的回應寫入 `caches.default`，
+  命中時帶 `X-Moedict-Edge-Cache: hit` 標頭。在此之前上表的 edge TTL 全是
+  裝飾。HTML shell 刻意不進 edge cache（release fallback 正確性依賴現渲染）。
+  deploy/rollback probe 一律帶 `_probe` cache-buster，不受影響。
+- **R2 讀取另有 per-isolate memo**（帳單稽核 2026-07 後新增）：
+  `src/api/r2-json-cache.ts` 對 pack bucket 與 xref/xref-by-id 做 10 分鐘
+  LRU memo（WeakMap 以 R2 binding 為 key，單元測試天然隔離）；
+  `src/utils/image-generation.ts` 對字型 probe、逐字 glyph SVG（含 negative
+  cache——R2 miss 也計費）與 Tauhu fallback 字型做同樣的 per-isolate 快取。
+  **資料上傳後**除了 edge TTL 還會多最長 10 分鐘的 memo 延遲。
 - 上傳新字典資料後，已被快取的詞條最長 **24 小時**才會自然更新。
 - 立即清除：`POST /api/cache/purge`，帶 `CACHE_PURGE_TOKEN`（Bearer 或
   `X-Cache-Purge-Token`），body 用 allowlist 內的 cache tags（如

--- a/src/api/handleDictionaryAPI.ts
+++ b/src/api/handleDictionaryAPI.ts
@@ -1,4 +1,5 @@
 import { CACHE_CONTROL, dictTagsForLang } from "./cache";
+import { readR2JsonCached } from "./r2-json-cache";
 import { dedupeHeteronyms } from "../utils/heteronym-dedup";
 import {
   stripLangPrefix,
@@ -390,13 +391,15 @@ async function fillBucket(
 ): Promise<{ data: DictionaryEntry | null; err: boolean }> {
   try {
     const bucketPath = `p${lang}ck/${bucket}.txt`;
-    const bucketObject = await env.DICTIONARY.get(bucketPath);
-    if (!bucketObject) {
+    // Memoized: bucket shards are the hottest R2 objects (billing audit
+    // 2026-07) and change only on data re-upload.
+    const responseData = (await readR2JsonCached(env.DICTIONARY, bucketPath)) as Record<
+      string,
+      DictionaryEntry
+    > | null;
+    if (!responseData) {
       return { data: null, err: true };
     }
-
-    const bucketData = await bucketObject.text();
-    const responseData = JSON.parse(bucketData) as Record<string, DictionaryEntry>;
     const key = escape(id);
     const part = responseData[key];
 
@@ -827,13 +830,12 @@ async function getCrossReferences(
 ): Promise<Array<{ lang: DictionaryLang; words: string[] }>> {
   try {
     const xrefPath = `${lang}/xref.json`;
-    const xrefObject = await env.DICTIONARY.get(xrefPath);
-    if (!xrefObject) {
+    // Memoized: this sidecar is re-read on EVERY entry lookup (once here,
+    // once for xref-by-id) — formerly two R2 GETs per dictionary request.
+    const xref = (await readR2JsonCached(env.DICTIONARY, xrefPath)) as XRefData | null;
+    if (!xref) {
       return [];
     }
-
-    const xrefData = await xrefObject.text();
-    const xref = JSON.parse(xrefData) as XRefData;
     const result: Array<{ lang: DictionaryLang; words: string[] }> = [];
 
     for (const [targetLang, words] of Object.entries(xref)) {
@@ -863,13 +865,10 @@ async function getCrossReferencesById(
 ): Promise<Array<{ lang: DictionaryLang; byId: Record<string, string[]> }>> {
   try {
     const xrefPath = `${lang}/xref-by-id.json`;
-    const xrefObject = await env.DICTIONARY.get(xrefPath);
-    if (!xrefObject) {
+    const xref = (await readR2JsonCached(env.DICTIONARY, xrefPath)) as XRefByIdData | null;
+    if (!xref) {
       return [];
     }
-
-    const xrefData = await xrefObject.text();
-    const xref = JSON.parse(xrefData) as XRefByIdData;
     const result: Array<{ lang: DictionaryLang; byId: Record<string, string[]> }> = [];
 
     for (const [targetLang, byTitle] of Object.entries(xref)) {

--- a/src/api/r2-json-cache.ts
+++ b/src/api/r2-json-cache.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-R2-binding memo of parsed JSON objects.
+ *
+ * WHY: the 2026-07 billing audit showed the dictionary Worker re-reading the
+ * same R2 objects on every request — 27M+ Class B GETs per cycle, dominated
+ * by `p{lang}ck/<bucket>.txt` shards and the per-lang `xref.json` /
+ * `xref-by-id.json` sidecars (the sidecars are read TWICE per entry lookup).
+ * These objects change only when dictionary data is re-uploaded (rare), so a
+ * short per-isolate memo removes the repeat GETs without meaningfully
+ * delaying data propagation — entry responses are edge-cached for 24h anyway
+ * (src/api/cache.ts), so a 10-minute memo is never the freshness bottleneck.
+ *
+ * Scoping: the memo is keyed on the R2 binding OBJECT via WeakMap. Each unit
+ * test constructs its own mock binding, so tests stay isolated for free;
+ * production reuses one binding per isolate, which is exactly the intended
+ * cache lifetime. Entries evict LRU beyond a small cap so a crawler walking
+ * distinct buckets cannot grow isolate memory unboundedly.
+ */
+
+interface CacheEntry {
+  value: unknown;
+  storedAt: number;
+}
+
+/** Structural subset of an R2 bucket binding used here (mock-friendly). */
+export interface R2JsonSource {
+  get(key: string): Promise<{ text(): Promise<string> } | null>;
+}
+
+export const R2_JSON_CACHE_TTL_MS = 600_000;
+export const R2_JSON_CACHE_MAX_ENTRIES = 24;
+
+const cachesBySource = new WeakMap<R2JsonSource, Map<string, CacheEntry>>();
+
+/**
+ * Read + JSON.parse an R2 object through the per-binding memo.
+ *
+ * Missing objects are cached as `null` — repeat misses are billed Class B
+ * operations too. JSON parse errors propagate to the caller and are NOT
+ * cached (the next read retries). `now` is injectable for TTL tests.
+ */
+export async function readR2JsonCached(
+  source: R2JsonSource,
+  key: string,
+  now: () => number = Date.now,
+): Promise<unknown> {
+  let cache = cachesBySource.get(source);
+  if (!cache) {
+    cache = new Map();
+    cachesBySource.set(source, cache);
+  }
+  const hit = cache.get(key);
+  if (hit && now() - hit.storedAt < R2_JSON_CACHE_TTL_MS) {
+    // Refresh recency: Map preserves insertion order, so re-inserting moves
+    // this key to the tail and eviction below always drops the oldest.
+    cache.delete(key);
+    cache.set(key, hit);
+    return hit.value;
+  }
+  const object = await source.get(key);
+  const value: unknown = object === null ? null : JSON.parse(await object.text());
+  cache.delete(key);
+  cache.set(key, { value, storedAt: now() });
+  while (cache.size > R2_JSON_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    /* v8 ignore next -- Map with size>0 always yields a key; defensive only */
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  return value;
+}

--- a/src/utils/image-generation.ts
+++ b/src/utils/image-generation.ts
@@ -280,10 +280,33 @@ export function getFontName(fontParam: string): string {
 }
 
 /**
+ * Per-isolate caches for the PNG render path, keyed on the R2 binding object
+ * (WeakMap → unit-test isolation for free; production reuses one binding per
+ * isolate). Billing audit 2026-07: this path generated ~100M R2 Class B GETs
+ * per cycle — one availability probe per render, one GET per character
+ * (misses included — those are billed too), and one fallback-font GET per
+ * fallback render. All three are immutable-ish objects; memoize them.
+ */
+const fontAvailabilityCache = new WeakMap<object, Map<string, boolean>>();
+const glyphSvgCache = new WeakMap<object, Map<string, string | null>>();
+const GLYPH_CACHE_MAX_ENTRIES = 2048;
+const fallbackFontCache = new WeakMap<object, Promise<Uint8Array | null>>();
+
+/**
  * 檢查字體是否在 R2 中可用
- * 通過檢查一個測試字符的 SVG 檔案是否存在
+ * 通過檢查一個測試字符的 SVG 檔案是否存在（結果依 FONTS binding 記憶，
+ * 每個 isolate 每種字型最多探測一次；probe 錯誤不快取，下次重試）
  */
 async function checkFontAvailability(fontName: string, env: Env): Promise<boolean> {
+  let cache = fontAvailabilityCache.get(env.FONTS);
+  if (!cache) {
+    cache = new Map();
+    fontAvailabilityCache.set(env.FONTS, cache);
+  }
+  const cached = cache.get(fontName);
+  if (cached !== undefined) {
+    return cached;
+  }
   try {
     // 使用 "萌" 字 (U+840C) 作為測試字符
     const testUnicode = 0x840c;
@@ -295,6 +318,7 @@ async function checkFontAvailability(fontName: string, env: Env): Promise<boolea
     const isAvailable = svgObject !== null;
 
     console.log(`[DEBUG] Font ${fontName} availability: ${isAvailable}`);
+    cache.set(fontName, isAvailable);
     return isAvailable;
   } catch (error) {
     console.error(`[DEBUG] Error checking font availability for ${fontName}:`, error);
@@ -303,22 +327,57 @@ async function checkFontAvailability(fontName: string, env: Env): Promise<boolea
 }
 
 /**
+ * 讀取單一字符的 SVG 內容，經 per-isolate LRU 快取（含 negative 快取——
+ * R2 miss 也是計費的 Class B 操作）。回傳 SVG 全文或 null（不存在）。
+ */
+async function fetchGlyphSvg(fonts: Env["FONTS"], svgPath: string): Promise<string | null> {
+  let cache = glyphSvgCache.get(fonts);
+  if (!cache) {
+    cache = new Map();
+    glyphSvgCache.set(fonts, cache);
+  }
+  if (cache.has(svgPath)) {
+    const cached = cache.get(svgPath) ?? null;
+    // 更新 LRU 順序（Map 保留插入順序；重插移至尾端）
+    cache.delete(svgPath);
+    cache.set(svgPath, cached);
+    return cached;
+  }
+  const svgObject = await fonts.get(svgPath);
+  const content = svgObject ? await svgObject.text() : null;
+  cache.set(svgPath, content);
+  while (cache.size > GLYPH_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  return content;
+}
+
+/**
  * 載入 Tauhu Oo 作為 resvg 的補完字型（fontBuffers）。只在某字元於 R2 找不到
  * 逐字 SVG、必須改用 <text> fallback 時才呼叫，避免每次產圖都多打一次 R2。
  */
 async function loadFallbackFontBuffer(env: Env): Promise<Uint8Array | null> {
-  if (!env.ASSETS) return null;
-  try {
-    const asset = await env.ASSETS.get(FALLBACK_FONT_ASSET_KEY);
-    if (!asset) {
-      console.log(`[DEBUG] Fallback font asset not found at ${FALLBACK_FONT_ASSET_KEY}`);
+  const assets = env.ASSETS; // capture: narrowing does not flow into the closure
+  if (!assets) return null;
+  const cached = fallbackFontCache.get(assets);
+  if (cached) return cached;
+  const loading = (async (): Promise<Uint8Array | null> => {
+    try {
+      const asset = await assets.get(FALLBACK_FONT_ASSET_KEY);
+      if (!asset) {
+        console.log(`[DEBUG] Fallback font asset not found at ${FALLBACK_FONT_ASSET_KEY}`);
+        return null;
+      }
+      return new Uint8Array(await asset.arrayBuffer());
+    } catch (error) {
+      console.error("[DEBUG] Failed to load fallback font buffer:", error);
       return null;
     }
-    return new Uint8Array(await asset.arrayBuffer());
-  } catch (error) {
-    console.error("[DEBUG] Failed to load fallback font buffer:", error);
-    return null;
-  }
+  })();
+  fallbackFontCache.set(assets, loading);
+  return loading;
 }
 
 /**
@@ -404,13 +463,11 @@ export async function generateTextSVGWithR2Fonts(
     );
 
     try {
-      // 從 R2 讀取 SVG 檔案
-      console.log(`[DEBUG] Attempting to fetch SVG from R2: ${svgPath}`);
-      const svgObject = await env.FONTS.get(svgPath);
+      // 從 R2 讀取 SVG 檔案（經 per-isolate LRU；重複字符與重複 miss 不再打 R2）
+      console.log(`[DEBUG] Fetching SVG (cached): ${svgPath}`);
+      const svgContent = await fetchGlyphSvg(env.FONTS, svgPath);
 
-      if (svgObject) {
-        console.log(`[DEBUG] SVG object found for ${char}, size: ${svgObject.size} bytes`);
-        const svgContent = await svgObject.text();
+      if (svgContent !== null) {
         console.log(`[DEBUG] SVG content length: ${svgContent.length} characters`);
 
         // 解析 SVG 內容，提取 path 元素

--- a/tests/unit/deployment-state.test.ts
+++ b/tests/unit/deployment-state.test.ts
@@ -253,10 +253,21 @@ describe("field-level schema validation (fail-closed)", () => {
     expect(() => checkStagingApprovalGate("sha", "", null)).toThrow(/prodDigest is required/);
   });
 
-  it("readCurrentDeployment / readStagingApproval / readVersionHistory default to the real .wrangler/releases/ dir (absent in this repo, so a safe read-only null/empty result)", () => {
-    expect(readCurrentDeployment()).toBeNull();
-    expect(readStagingApproval()).toBeNull();
-    expect(readVersionHistory()).toEqual([]);
+  it("readCurrentDeployment / readStagingApproval / readVersionHistory default to the cwd-relative .wrangler/releases/ dir (safe null/empty when absent)", () => {
+    // Run from a scratch cwd: the repo checkout may legitimately hold real
+    // deployment state in .wrangler/releases/ (it does after any local
+    // deploy), so "absent" must be arranged, not assumed.
+    const scratch = mkdtempSync(join(tmpdir(), "moedict-state-default-"));
+    const prevCwd = process.cwd();
+    try {
+      process.chdir(scratch);
+      expect(readCurrentDeployment()).toBeNull();
+      expect(readStagingApproval()).toBeNull();
+      expect(readVersionHistory()).toEqual([]);
+    } finally {
+      process.chdir(prevCwd);
+    }
+    rmSync(scratch, { recursive: true, force: true });
   });
 });
 

--- a/tests/unit/r2-json-cache.test.ts
+++ b/tests/unit/r2-json-cache.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the per-R2-binding JSON memo (src/api/r2-json-cache.ts) and
+ * its integration into the dictionary handler's bucket/xref reads.
+ *
+ * The memo exists to kill repeat R2 Class B GETs (2026-07 billing audit);
+ * these tests defend the contracts that make it safe: WeakMap isolation per
+ * binding, TTL-bounded staleness, LRU-bounded memory, negative caching, and
+ * error transparency.
+ */
+import { describe, expect, it } from "vite-plus/test";
+import {
+  R2_JSON_CACHE_MAX_ENTRIES,
+  R2_JSON_CACHE_TTL_MS,
+  readR2JsonCached,
+  type R2JsonSource,
+} from "../../src/api/r2-json-cache";
+import { handleDictionaryAPI } from "../../src/api/handleDictionaryAPI";
+
+function makeSource(objects: Record<string, string | undefined>): R2JsonSource & {
+  getCalls: string[];
+} {
+  const getCalls: string[] = [];
+  return {
+    getCalls,
+    get: async (key: string) => {
+      getCalls.push(key);
+      const body = objects[key];
+      if (body === undefined) return null;
+      return { text: async () => body };
+    },
+  };
+}
+
+describe("readR2JsonCached", () => {
+  it("fetches once and serves repeats from the memo within the TTL", async () => {
+    const source = makeSource({ "a/xref.json": '{"t":{}}' });
+    const first = await readR2JsonCached(source, "a/xref.json");
+    const second = await readR2JsonCached(source, "a/xref.json");
+    expect(first).toEqual({ t: {} });
+    expect(second).toEqual({ t: {} });
+    expect(source.getCalls).toEqual(["a/xref.json"]);
+  });
+
+  it("caches misses as null (repeat misses are billed too)", async () => {
+    const source = makeSource({});
+    expect(await readR2JsonCached(source, "absent.json")).toBeNull();
+    expect(await readR2JsonCached(source, "absent.json")).toBeNull();
+    expect(source.getCalls).toEqual(["absent.json"]);
+  });
+
+  it("re-fetches after the TTL elapses", async () => {
+    const source = makeSource({ "k.json": "1" });
+    let clock = 0;
+    const now = () => clock;
+    expect(await readR2JsonCached(source, "k.json", now)).toBe(1);
+    clock = R2_JSON_CACHE_TTL_MS - 1;
+    expect(await readR2JsonCached(source, "k.json", now)).toBe(1);
+    expect(source.getCalls).toHaveLength(1);
+    clock = R2_JSON_CACHE_TTL_MS;
+    expect(await readR2JsonCached(source, "k.json", now)).toBe(1);
+    expect(source.getCalls).toHaveLength(2);
+  });
+
+  it("evicts the least-recently-used key beyond the cap, keeping refreshed keys", async () => {
+    const objects: Record<string, string> = {};
+    for (let i = 0; i <= R2_JSON_CACHE_MAX_ENTRIES; i++) objects[`k${i}.json`] = String(i);
+    const source = makeSource(objects);
+    for (let i = 0; i < R2_JSON_CACHE_MAX_ENTRIES; i++) {
+      await readR2JsonCached(source, `k${i}.json`);
+    }
+    // Touch k0 so it becomes most-recent; adding one more must evict k1.
+    await readR2JsonCached(source, "k0.json");
+    await readR2JsonCached(source, `k${R2_JSON_CACHE_MAX_ENTRIES}.json`);
+    const callsBefore = source.getCalls.length;
+    await readR2JsonCached(source, "k0.json"); // still cached
+    expect(source.getCalls).toHaveLength(callsBefore);
+    await readR2JsonCached(source, "k1.json"); // evicted → refetch
+    expect(source.getCalls).toHaveLength(callsBefore + 1);
+  });
+
+  it("isolates caches per binding object and propagates parse errors uncached", async () => {
+    const a = makeSource({ "k.json": "1" });
+    const b = makeSource({ "k.json": "2" });
+    expect(await readR2JsonCached(a, "k.json")).toBe(1);
+    expect(await readR2JsonCached(b, "k.json")).toBe(2);
+    expect(a.getCalls).toHaveLength(1);
+    expect(b.getCalls).toHaveLength(1);
+
+    const broken = makeSource({ "k.json": "not-json" });
+    await expect(readR2JsonCached(broken, "k.json")).rejects.toThrow();
+    await expect(readR2JsonCached(broken, "k.json")).rejects.toThrow();
+    expect(broken.getCalls).toHaveLength(2); // errors are not cached
+  });
+});
+
+describe("dictionary handler memoization", () => {
+  // 萌 = U+840C → escape() key %u840C; bucketOf for lang "a" = 0x840c % 1024 = 12.
+  const BUCKET_BODY = JSON.stringify({ "%u840C": { t: "萌", h: [{ d: [{ f: "義" }] }] } });
+
+  function makeDictionaryEnv() {
+    const source = makeSource({
+      "pack/12.txt": BUCKET_BODY,
+      "a/xref.json": "{}",
+      "a/xref-by-id.json": "{}",
+    });
+    return { env: { DICTIONARY: source }, source };
+  }
+
+  it("reads bucket and xref sidecars from R2 once across repeated lookups", async () => {
+    const { env, source } = makeDictionaryEnv();
+    const url = new URL("http://localhost/api/%E8%90%8C.json");
+    const first = await handleDictionaryAPI(new Request(url), url, env);
+    expect(first?.status).toBe(200);
+    const callsAfterFirst = [...source.getCalls];
+    expect(callsAfterFirst).toContain("pack/12.txt");
+    expect(callsAfterFirst).toContain("a/xref.json");
+    expect(callsAfterFirst).toContain("a/xref-by-id.json");
+
+    const second = await handleDictionaryAPI(new Request(url), url, env);
+    expect(second?.status).toBe(200);
+    expect(source.getCalls).toEqual(callsAfterFirst); // zero new R2 GETs
+  });
+
+  it("does not leak memo state across distinct DICTIONARY bindings", async () => {
+    const first = makeDictionaryEnv();
+    const url = new URL("http://localhost/api/%E8%90%8C.json");
+    await handleDictionaryAPI(new Request(url), url, first.env);
+
+    const second = makeDictionaryEnv();
+    const res = await handleDictionaryAPI(new Request(url), url, second.env);
+    expect(res?.status).toBe(200);
+    expect(second.source.getCalls).toContain("pack/12.txt");
+  });
+});

--- a/tests/unit/worker-dispatch.test.ts
+++ b/tests/unit/worker-dispatch.test.ts
@@ -88,11 +88,10 @@ describe("dispatch — /api/config", () => {
     });
   });
 
-  it("sets fixed CORS and no-store so env changes are not edge-pinned", async () => {
+  it("sets fixed CORS and short edge TTLs (config is static per deploy; probes cache-bust)", async () => {
     const res = await dispatch(req("/api/config"), makeEnv());
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
-    expect(res.headers.get("cache-control")).toMatch(/no-store|max-age=0|private/i);
-    expect(res.headers.get("cache-control") ?? "").not.toMatch(/s-maxage=[1-9]/);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, s-maxage=300");
   });
 
   it("serves empty strings when vars are absent", async () => {
@@ -119,7 +118,7 @@ describe("dispatch — global version headers", () => {
     expect(res.headers.get("X-Moedict-Version")).toBe(metadata.id);
     expect(res.headers.get("X-Moedict-Release")).toBe(metadata.tag);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60, s-maxage=300");
   });
 
   it("decorates dictionary API responses without changing body, CORS, or cache policy", async () => {
@@ -261,7 +260,7 @@ describe("respondWithConfigApi — no edge pin", () => {
     expect(match).not.toHaveBeenCalled();
     expect(put).not.toHaveBeenCalled();
     expect(waitUntil).not.toHaveBeenCalled();
-    expect(res.headers.get("cache-control")).toMatch(/no-store|max-age=0|private/i);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, s-maxage=300");
     expect(await res.json()).toEqual({
       assetBaseUrl: "live-assets",
       dictionaryBaseUrl: "live-dict",
@@ -274,7 +273,7 @@ describe("respondWithConfigApi — no edge pin", () => {
     const res = await respondWithConfigApi(req("/api/config"), makeEnv());
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("cache-control")).toMatch(/no-store|max-age=0|private/i);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, s-maxage=300");
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
     expect(await res.json()).toMatchObject({
       assetBaseUrl: "https://r2-assets.test.local",

--- a/tests/unit/worker-edge-cache.test.ts
+++ b/tests/unit/worker-edge-cache.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the dispatch-boundary edge cache layer (worker/index.ts).
+ *
+ * Cloudflare never edge-caches Worker-generated responses on its own; the
+ * 2026-07 billing audit showed bots re-rendering identical responses on
+ * every hit. dispatch() now reads through `caches.default` and writes back
+ * responses that opt in via `isEdgeCacheable`. These tests install a fake
+ * `caches` global (absent in plain Node, so every other unit test exercises
+ * the no-op path) and defend: read-through hits, opt-in criteria, probe
+ * safety (unique URLs miss), and failure isolation (cache errors never break
+ * rendering).
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { dispatch, isEdgeCacheable } from "../../worker/index";
+
+type WorkerEnv = Parameters<typeof dispatch>[1];
+type WorkerCtx = NonNullable<Parameters<typeof dispatch>[2]>;
+
+interface FakeCacheControls {
+  store: Map<string, Response>;
+  matchCalls: number;
+  putCalls: number;
+}
+
+function installFakeEdgeCache(
+  overrides: {
+    match?: (request: Request) => Promise<Response | undefined>;
+    put?: (request: Request, response: Response) => Promise<void>;
+  } = {},
+): FakeCacheControls {
+  const controls: FakeCacheControls = { store: new Map(), matchCalls: 0, putCalls: 0 };
+  const fake = {
+    default: {
+      match: async (request: Request) => {
+        controls.matchCalls += 1;
+        if (overrides.match) return overrides.match(request);
+        const hit = controls.store.get(request.url);
+        return hit ? hit.clone() : undefined;
+      },
+      put: async (request: Request, response: Response) => {
+        controls.putCalls += 1;
+        if (overrides.put) return overrides.put(request, response);
+        controls.store.set(request.url, response);
+      },
+    },
+  };
+  // Test seam: the fake implements only the two Cache methods dispatch uses.
+  globalThis.caches = fake as unknown as typeof caches;
+  return controls;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "caches");
+});
+
+function makeEnv() {
+  const getCalls: string[] = [];
+  const env = {
+    DICTIONARY: {
+      getCalls,
+      get: async (key: string) => {
+        getCalls.push(key);
+        if (key === "search-index/a.json") {
+          return { text: async () => '{"terms":["萌"]}' };
+        }
+        return null;
+      },
+    },
+  } as unknown as WorkerEnv;
+  return { env, getCalls };
+}
+
+const INDEX_URL = "http://localhost/api/search-index/a.json";
+
+describe("dispatch edge cache layer", () => {
+  it("stores an s-maxage GET once and serves the repeat from cache with a hit marker", async () => {
+    const controls = installFakeEdgeCache();
+    const { env, getCalls } = makeEnv();
+
+    const first = await dispatch(new Request(INDEX_URL), env);
+    expect(first.status).toBe(200);
+    expect(first.headers.get("X-Moedict-Edge-Cache")).toBeNull();
+    await first.text();
+    expect(controls.store.size).toBe(1);
+    expect(getCalls).toHaveLength(1);
+
+    const second = await dispatch(new Request(INDEX_URL), env);
+    expect(second.status).toBe(200);
+    expect(second.headers.get("X-Moedict-Edge-Cache")).toBe("hit");
+    expect(await second.json()).toEqual({ terms: ["萌"] });
+    expect(getCalls).toHaveLength(1); // renderer never re-invoked
+  });
+
+  it("keeps distinct URLs distinct, so cache-busted probes always re-render", async () => {
+    const controls = installFakeEdgeCache();
+    const { env, getCalls } = makeEnv();
+    await dispatch(new Request(`${INDEX_URL}?_probe=a`), env);
+    const second = await dispatch(new Request(`${INDEX_URL}?_probe=b`), env);
+    expect(second.headers.get("X-Moedict-Edge-Cache")).toBeNull();
+    expect(getCalls).toHaveLength(2);
+    expect(controls.store.size).toBe(2);
+  });
+
+  it("never stores no-store responses (404 fallback)", async () => {
+    const controls = installFakeEdgeCache();
+    const { env } = makeEnv();
+    const res = await dispatch(new Request("http://localhost/some/random.txt"), env);
+    expect(res.status).toBe(404);
+    expect(controls.store.size).toBe(0);
+  });
+
+  it("never consults or writes the cache for non-GET requests", async () => {
+    const controls = installFakeEdgeCache();
+    const { env } = makeEnv();
+    await dispatch(new Request(INDEX_URL, { method: "HEAD" }), env);
+    await dispatch(new Request(INDEX_URL, { method: "POST" }), env);
+    expect(controls.matchCalls).toBe(0);
+    expect(controls.store.size).toBe(0);
+  });
+
+  it("renders normally when the cache lookup throws", async () => {
+    installFakeEdgeCache({
+      match: async () => {
+        throw new Error("cache backend unavailable");
+      },
+    });
+    const { env } = makeEnv();
+    const res = await dispatch(new Request(INDEX_URL), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ terms: ["萌"] });
+  });
+
+  it("returns the response even when the cache write rejects, via ctx.waitUntil", async () => {
+    const controls = installFakeEdgeCache({
+      put: async () => {
+        throw new Error("write failed");
+      },
+    });
+    const { env } = makeEnv();
+    const waited: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => {
+        waited.push(p);
+      },
+    } as unknown as WorkerCtx;
+    const res = await dispatch(new Request(INDEX_URL), env, ctx);
+    expect(res.status).toBe(200);
+    expect(waited).toHaveLength(1);
+    await Promise.all(waited); // .catch() arm swallows the rejection
+    expect(controls.putCalls).toBe(1);
+  });
+
+  it("fires the cache write without ctx (fire-and-forget) and serves it next time", async () => {
+    const controls = installFakeEdgeCache();
+    const { env } = makeEnv();
+    await dispatch(new Request(INDEX_URL), env);
+    await vi.waitFor(() => {
+      expect(controls.putCalls).toBe(1);
+    });
+    const second = await dispatch(new Request(INDEX_URL), env);
+    expect(second.headers.get("X-Moedict-Edge-Cache")).toBe("hit");
+  });
+});
+
+describe("isEdgeCacheable", () => {
+  const GET = new Request("http://localhost/x");
+  const ok = (headers: Record<string, string>, status = 200) =>
+    new Response("body", { status, headers });
+
+  it("accepts a GET 200 with positive s-maxage and non-HTML content type", () => {
+    expect(
+      isEdgeCacheable(
+        GET,
+        ok({ "Cache-Control": "public, max-age=0, s-maxage=60", "Content-Type": "image/png" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects non-GET, non-200, no-store, private, missing/zero s-maxage, Set-Cookie, and HTML", () => {
+    const cacheable = { "Cache-Control": "public, s-maxage=60", "Content-Type": "image/png" };
+    expect(
+      isEdgeCacheable(new Request("http://localhost/x", { method: "POST" }), ok(cacheable)),
+    ).toBe(false);
+    expect(isEdgeCacheable(GET, ok(cacheable, 404))).toBe(false);
+    expect(isEdgeCacheable(GET, ok({ "Cache-Control": "no-store, s-maxage=60" }))).toBe(false);
+    expect(isEdgeCacheable(GET, ok({ "Cache-Control": "private, s-maxage=60" }))).toBe(false);
+    expect(isEdgeCacheable(GET, ok({ "Cache-Control": "public, max-age=300" }))).toBe(false);
+    expect(isEdgeCacheable(GET, ok({ "Cache-Control": "public, s-maxage=0" }))).toBe(false);
+    // happy-dom's Headers drops the forbidden Set-Cookie header from real
+    // Response objects, so this arm uses a structural fake (test seam).
+    const withSetCookie = {
+      status: 200,
+      headers: {
+        get: (key: string) => (key === "Cache-Control" ? "public, s-maxage=60" : null),
+        has: (key: string) => key === "Set-Cookie",
+      },
+    } as unknown as Response;
+    expect(isEdgeCacheable(GET, withSetCookie)).toBe(false);
+    expect(
+      isEdgeCacheable(
+        GET,
+        ok({ "Cache-Control": "public, s-maxage=60", "Content-Type": "text/html; charset=utf-8" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats absent Cache-Control / Content-Type headers as empty strings", () => {
+    const noCacheControl = {
+      status: 200,
+      headers: { get: () => null, has: () => false },
+    } as unknown as Response;
+    expect(isEdgeCacheable(GET, noCacheControl)).toBe(false); // no s-maxage → reject
+
+    const noContentType = {
+      status: 200,
+      headers: {
+        get: (key: string) => (key === "Cache-Control" ? "public, s-maxage=60" : null),
+        has: () => false,
+      },
+    } as unknown as Response;
+    expect(isEdgeCacheable(GET, noContentType)).toBe(true); // opt-in via s-maxage stands
+  });
+});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -189,7 +189,7 @@ function getAssetsBucket(env: Env): R2Bucket | null {
   return candidate as R2Bucket;
 }
 
-const CONFIG_API_CACHE_CONTROL = "no-store";
+const CONFIG_API_CACHE_CONTROL = "public, max-age=60, s-maxage=300";
 
 /** Fixed CORS for public config / dictionary / static GETs under Workers Cache. */
 const PUBLIC_CORS_HEADERS: Record<string, string> = {
@@ -203,7 +203,12 @@ export async function respondWithConfigApi(
   env: Env,
   _ctx?: Pick<ExecutionContext, "waitUntil">,
 ): Promise<Response> {
-  // Env-backed; must not be edge-pinned via Workers Cache or Cache API.
+  // Env-backed but effectively static per deploy (values only change with a
+  // release). This was `no-store` and /api/config was the single most
+  // requested path on the zone (~3.5M/week), each hit invoking the Worker.
+  // Short TTLs are safe: deploy/rollback probes always cache-bust
+  // (scripts/lib/smoke-probe.mjs `_probe` param), so rollout verification
+  // never reads a stale cached config.
   return new Response(
     JSON.stringify({
       assetBaseUrl: env.ASSET_BASE_URL || "",
@@ -625,17 +630,60 @@ async function dispatchCore(request: Request, env: Env, ctx?: ExecutionContext):
 }
 
 /**
- * Decorate every Worker response with deployment metadata.
+ * Edge-cacheability predicate for Worker-generated responses.
  *
- * Keeping this at the dispatch boundary ensures API, compatibility, and
- * fallback routes expose the same version headers without buffering or
- * branching each response path.
+ * Cloudflare does NOT edge-cache Worker responses on its own — every
+ * `s-maxage` in src/api/cache.ts was decorative until dispatch() started
+ * writing through `caches.default` (2026-07 billing audit: bots re-rendered
+ * identical PNGs and re-read identical dictionary shards on every hit).
+ * Opt-in is response-driven: any GET 200 whose Cache-Control carries a
+ * positive s-maxage, except HTML shells (release-fallback correctness
+ * depends on fresh shell rendering) and anything no-store/private or
+ * carrying Set-Cookie.
+ */
+export function isEdgeCacheable(request: Request, response: Response): boolean {
+  if (request.method !== "GET" || response.status !== 200) return false;
+  const cacheControl = response.headers.get("Cache-Control") ?? "";
+  if (/\b(?:no-store|private)\b/i.test(cacheControl)) return false;
+  if (!/\bs-maxage=[1-9]/i.test(cacheControl)) return false;
+  if (response.headers.has("Set-Cookie")) return false;
+  const contentType = response.headers.get("Content-Type") ?? "";
+  return !contentType.includes("text/html");
+}
+
+/**
+ * Dispatch boundary: edge-cache read-through, then version-header
+ * decoration on every response (API, compatibility, and fallback routes all
+ * expose the same metadata without per-route branching), then a best-effort
+ * edge-cache write for responses that opt in via `isEdgeCacheable`.
  */
 export async function dispatch(
   request: Request,
   env: Env,
   ctx?: ExecutionContext,
 ): Promise<Response> {
+  // Serve straight from the edge cache when a previous dispatch stored this
+  // exact URL. Deploy/rollback probes always carry a unique `_probe`
+  // cache-buster, so rollout verification never reads a cached entry. The
+  // `caches` global is absent in plain-Node unit tests — the layer degrades
+  // to a no-op there (and on *.workers.dev, where cache.put is a no-op).
+  const edgeCache = typeof caches !== "undefined" ? caches.default : undefined;
+  if (edgeCache && request.method === "GET") {
+    try {
+      const hit = await edgeCache.match(request);
+      if (hit) {
+        const headers = new Headers(hit.headers);
+        headers.set("X-Moedict-Edge-Cache", "hit");
+        return new Response(hit.body, {
+          status: hit.status,
+          statusText: hit.statusText,
+          headers,
+        });
+      }
+    } catch {
+      // A cache lookup failure must never take down rendering.
+    }
+  }
   const response = await dispatchCore(request, env, ctx);
   const headers = new Headers(response.headers);
   const versionHeaders = getVersionHeaders(env.CF_VERSION_METADATA);
@@ -646,11 +694,23 @@ export async function dispatch(
   } else {
     headers.delete("X-Moedict-Release");
   }
-  return new Response(response.body, {
+  const decorated = new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
   });
+  if (edgeCache && isEdgeCacheable(request, decorated)) {
+    // Promise.resolve guards non-conformant Cache stubs (tests stub put as a plain spy).
+    const putPromise = Promise.resolve(edgeCache.put(request, decorated.clone())).catch(() => {
+      // Best-effort: a failed put only means the next request re-renders.
+    });
+    if (ctx) {
+      ctx.waitUntil(putPromise);
+    } else {
+      void putPromise;
+    }
+  }
+  return decorated;
 }
 
 /**


### PR DESCRIPTION
See commit message. Kills the moedict share of the Cloudflare bill: PNG renders and dictionary lookups were never edge-cached (Worker responses need explicit caches.default writes), the PNG path did up to 51 R2 GETs + a WASM render per request, and the xref sidecars were fetched twice per lookup. Unit 1564/1564 (ratchet 100×4), integration 99/99, e2e 96/96.