### PR TITLE
docs: record third zero-downtime ship 2026-07-13 (edge cache release)

### DIFF
--- a/notes/零停機部署筆記.md
+++ b/notes/零停機部署筆記.md
@@ -2,7 +2,7 @@
 
 > **適用日期：** 2026-07-12（staging）/ 2026-07-13（production）  
 > **目的：** 給值班操作者與維護者的可執行說明。這份筆記是 `notes/重要路由筆記.md` 同等重要、但更完整的部署運行手冊。  
-> **目前狀態：** Task 4（config／scripts／docs 全整合）已完成。**Production 最新出貨（2026-07-13，第二次）**：release `b11d2dcb-5db141ad4cd4`（main tip `b11d2dcb`，含 #148 的 rollback propagation wait 與 coverage gate ratchet），version UUID `a01f849f-d220-4892-baa8-697caf57e697`，finalized `2026-07-13T01:27:46.858Z`（UTC）。前一次為 release `0a2599b-5db141ad4cd4`（version UUID `5699a0f8-e741-41ca-90d8-323fbe8de41c`，finalized `2026-07-12T23:31:20.799Z`）。`www.moedict.tw` 正在跑新路徑。
+> **目前狀態：** Task 4（config／scripts／docs 全整合）已完成。**Production 最新出貨（2026-07-13，第三次）**：release `c7aa7d03-8bce95414453`（#150 edge cache + R2 memo，billing audit），version UUID `af4e24ad-98be-4a41-ae0d-15e5fa5da116`，finalized `2026-07-13T03:12:33.710Z`。此次第一輪 phase-1 override smoke 因 edge propagation 誤差 fail-safe rollback（restore old@100 單獨），依 §5.1a 冪等重跑成功——協定實戰驗證。前兩次：`b11d2dcb-5db141ad4cd4`（#148）、`0a2599b-5db141ad4cd4`。`www.moedict.tw` 正在跑新路徑，且 `/api/*`、`*.png` 等 s-maxage 路由自本版起真正進 edge cache（`cf-cache-status: HIT` 時 Worker 不會被呼叫）。
 
 ## 1. 問題與根因
 


### PR DESCRIPTION
Runbook status update: release c7aa7d03-8bce95414453 (#150) live; first phase-1 attempt fail-safe rolled back on propagation variance, idempotent §5.1a retry succeeded — first real-incident validation of the protocol.