### PR TITLE
fix: 兩岸辭典大陸音顯示錯亂（#156）

### DIFF
--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -15,7 +15,7 @@ import { cleanTextForTTS, speakText } from "../utils/tts-utils";
 import { getAudioUrl, playAudioUrl } from "../utils/audio-utils";
 import { AUDIO_CDN_MAP } from "../utils/media-cdn";
 import { rightAngle } from "../utils/ruby2hruby";
-import { decorateRuby } from "../utils/bopomofo-pinyin-utils";
+import { decorateRuby, formatBopomofo, formatPinyin } from "../utils/bopomofo-pinyin-utils";
 import { convertPinyinByLang } from "../utils/pinyin-preference-utils";
 import {
   addStarWord,
@@ -1188,6 +1188,28 @@ export function DictionaryPage({ word, lang, idx: targetDefIdx }: DictionaryPage
                   </span>
                 </TitlePronunciation>
               </h1>
+              {/* 兩岸辭典大陸音（陸⃝）：rubyData.pinyin/bopomofo 此時為 decorateRuby
+                  拆出的大陸讀音，cnSpecific 標記其存在。放在 h1 之後的 div，讓遠端
+                  legacy `.result h1+div small.cn-specific:before{content:"陸"}` 標籤
+                  與 `div.cn-specific.bopomofo` 底色生效（g0v/moedict.tw#156）。 */}
+              {lang === "c" && rubyData.cnSpecific && (rubyData.pinyin || rubyData.bopomofo) && (
+                <div className="cn-specific bopomofo">
+                  <small className="alternative cn-specific">
+                    {rubyData.pinyin && (
+                      <span
+                        className="pinyin"
+                        dangerouslySetInnerHTML={{ __html: formatPinyin(rubyData.pinyin) }}
+                      />
+                    )}
+                    {rubyData.bopomofo && (
+                      <span
+                        className="bopomofo"
+                        dangerouslySetInnerHTML={{ __html: formatBopomofo(rubyData.bopomofo) }}
+                      />
+                    )}
+                  </small>
+                </div>
+              )}
               {hakkaReadings.length > 0 && (
                 <div className="bopomofo">
                   <span className="pinyin">

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -15,7 +15,7 @@ import { cleanTextForTTS, speakText } from "../utils/tts-utils";
 import { getAudioUrl, playAudioUrl } from "../utils/audio-utils";
 import { AUDIO_CDN_MAP } from "../utils/media-cdn";
 import { rightAngle } from "../utils/ruby2hruby";
-import { decorateRuby, formatBopomofo, formatPinyin } from "../utils/bopomofo-pinyin-utils";
+import { decorateRuby } from "../utils/bopomofo-pinyin-utils";
 import { convertPinyinByLang } from "../utils/pinyin-preference-utils";
 import {
   addStarWord,
@@ -1191,21 +1191,17 @@ export function DictionaryPage({ word, lang, idx: targetDefIdx }: DictionaryPage
               {/* 兩岸辭典大陸音（陸⃝）：rubyData.pinyin/bopomofo 此時為 decorateRuby
                   拆出的大陸讀音，cnSpecific 標記其存在。放在 h1 之後的 div，讓遠端
                   legacy `.result h1+div small.cn-specific:before{content:"陸"}` 標籤
-                  與 `div.cn-specific.bopomofo` 底色生效（g0v/moedict.tw#156）。 */}
+                  與 `div.cn-specific.bopomofo` 底色生效（g0v/moedict.tw#156）。
+                  拼音／注音以純文字輸出（不套 formatPinyin/formatBopomofo 的
+                  `.tone` span）—— legacy `span .tone{float:right}` 會把聲調母音
+                  推到整條區塊最右側造成跑版，主標題台灣音本來也是純文字呈現，
+                  這裡比照辦理讓聲調留在母音上。 */}
               {lang === "c" && rubyData.cnSpecific && (rubyData.pinyin || rubyData.bopomofo) && (
                 <div className="cn-specific bopomofo">
                   <small className="alternative cn-specific">
-                    {rubyData.pinyin && (
-                      <span
-                        className="pinyin"
-                        dangerouslySetInnerHTML={{ __html: formatPinyin(rubyData.pinyin) }}
-                      />
-                    )}
+                    {rubyData.pinyin && <span className="pinyin">{rubyData.pinyin.trim()}</span>}
                     {rubyData.bopomofo && (
-                      <span
-                        className="bopomofo"
-                        dangerouslySetInnerHTML={{ __html: formatBopomofo(rubyData.bopomofo) }}
-                      />
+                      <span className="bopomofo">{rubyData.bopomofo.trim()}</span>
                     )}
                   </small>
                 </div>

--- a/src/utils/bopomofo-pinyin-utils.ts
+++ b/src/utils/bopomofo-pinyin-utils.ts
@@ -124,6 +124,19 @@ export function decorateRuby(params: {
   let processedPinyin = rawPinyin;
   let processedBopomofo = bopomofo || trsToBpmf(LANG, rawPinyin) || "";
 
+  // The dictionary API's decodeLangPart converts the legacy 陸⃝ (陸 + U+20DD
+  // COMBINING ENCLOSING CIRCLE) Mainland-reading marker that lives inside the
+  // 兩岸辭典 b/p reading fields into its regional-label markup
+  // `<span class="regional part-of-speech">陸</span> `. The reading-splitting
+  // logic below (and the LANG==='c' block near the end) still keys off the bare
+  // 陸⃝ marker; left as a span its `/` characters trip the `陸.` and `[變|/]`
+  // regexes, emitting a mangled `span>` fragment with the Mainland tone marks
+  // floating off to the side (g0v/moedict.tw#156). Fold the span back to the
+  // X⃝ marker so every downstream rule matches the shape it was written for.
+  const regionalMarkerSpan = /<span class="regional part-of-speech">([^<]+)<\/span>\s?/g;
+  processedPinyin = processedPinyin.replace(regionalMarkerSpan, "$1⃝");
+  processedBopomofo = processedBopomofo.replace(regionalMarkerSpan, "$1⃝");
+
   if (LANG !== "c") {
     processedPinyin = processedPinyin.replace(/<[^>]*>/g, "").replace(/（.*）/, "");
     processedBopomofo = processedBopomofo.replace(/<[^>]*>/g, "");

--- a/tests/e2e/cross-strait-comparison.spec.ts
+++ b/tests/e2e/cross-strait-comparison.spec.ts
@@ -1,4 +1,28 @@
 import { expect, test } from "./_fixtures";
+import { waitForAppReady } from "./readiness";
+
+test.describe("cross-strait Mainland pronunciation (兩岸辭典 大陸音)", () => {
+  // Regression for g0v/moedict.tw#156: the API rewrites the legacy 陸⃝ Mainland
+  // marker into `<span class="regional part-of-speech">陸</span>`, which used to
+  // slip past decorateRuby's reading-splitter and render a mangled `span>`
+  // fragment with the tone marks floating off to the side.
+  test("renders 測度's Mainland reading in a 陸 block without a mangled span", async ({ page }) => {
+    await page.goto("/~%E6%B8%AC%E5%BA%A6");
+    await waitForAppReady(page, "dictionary");
+
+    const cnSpecific = page.locator(".result .entry-heading small.alternative.cn-specific");
+    await expect(cnSpecific).toBeVisible();
+
+    // The clean Mainland reading is present (度 tone is ˊ / ó, vs Taiwan ˋ / ò).
+    await expect(cnSpecific.locator(".pinyin")).toContainText("cèduó");
+    await expect(cnSpecific.locator(".bopomofo")).toContainText("ㄉㄨㄛ");
+
+    // No leaked markup text anywhere in the heading (the #156 symptom).
+    const headingText = await page.locator(".result .entry-heading").innerText();
+    expect(headingText).not.toContain("span>");
+    expect(headingText).not.toContain("part-of-speech");
+  });
+});
 
 test.describe("cross-strait comparison category", () => {
   test("renders Taiwan and Mainland terms as separate table links", async ({ page }) => {

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -394,6 +394,18 @@ export function collectDictionaryFixtures(): FixtureEntry[] {
     httpMetadata: { contentType: "text/plain; charset=utf-8" },
   });
 
+  // 兩岸辭典 bucket 44 — contains 測度 (測 = U+6E2C, 28204 % 128 = 44),
+  // a cross-strait entry carrying a Mainland (陸⃝) reading in its b/p fields.
+  // Seeded so /c/測度.json exercises the Mainland-pronunciation rendering
+  // path (g0v/moedict.tw#156).
+  const mainlandReadingKey = "pcck/44.txt";
+  entries.push({
+    bucket: "DICTIONARY",
+    key: mainlandReadingKey,
+    body: required(path.join(DATA_DICT, "pcck", "44.txt"), mainlandReadingKey),
+    httpMetadata: { contentType: "text/plain; charset=utf-8" },
+  });
+
   // CNS11643 golden fixture: 䴉 (U+4D09, CNS 4-6C51) — shard 4D, key 4D09.json
   const cnsGoldenKey = "cns/by-codepoint/4D/4D09.json";
   const cnsGoldenPath = path.join(DATA_DICT, "cns", "by-codepoint", "4D", "4D09.json");

--- a/tests/unit/bopomofo-pinyin-utils.test.ts
+++ b/tests/unit/bopomofo-pinyin-utils.test.ts
@@ -125,6 +125,33 @@ describe("decorateRuby", () => {
     expect(result.cnSpecific).toBe("cn-specific");
   });
 
+  it("normalizes the API regional-marker span in the Mainland reading (g0v/moedict.tw#156)", () => {
+    // The dictionary API's decodeLangPart rewrites the legacy 陸⃝ (陸 + U+20DD)
+    // Mainland marker in the b/p fields into `<span class="regional
+    // part-of-speech">陸</span> ` before decorateRuby sees it. Feeding that exact
+    // shape (as /api/~測度.json returns) must NOT leak a mangled `span>` fragment
+    // into any output field, and must still split out the clean Mainland reading.
+    const result = decorateRuby({
+      LANG: "c",
+      title: '<a href="./#~測">測</a><a href="./#~度">度</a>',
+      bopomofo: 'ㄘㄜˋ　ㄉㄨㄛˋ<br><span class="regional part-of-speech">陸</span> ㄘㄜˋ　ㄉㄨㄛˊ',
+      pinyin: 'cèduò<br><span class="regional part-of-speech">陸</span> cèduó',
+    });
+    expect(result.cnSpecific).toBe("cn-specific");
+    // Clean Mainland reading (the 度 tone differs: ˋ→ˊ / ò→ó).
+    expect(result.pinyin).toContain("cèduó");
+    expect(result.bopomofo).toContain("ㄉㄨㄛˊ");
+    // No mangled span fragment anywhere the UI renders it.
+    for (const field of [result.pinyin, result.bopomofo, result.bAlt, result.pAlt, result.ruby]) {
+      expect(field).not.toContain("span>");
+      expect(field).not.toContain("part-of-speech");
+    }
+    // The garbage previously landed in bAlt/pAlt (the h1 `.alternative` block);
+    // with the marker normalized the alternate-reading fields stay empty.
+    expect(result.bAlt).toBe("");
+    expect(result.pAlt).toBe("");
+  });
+
   it("computes rbspan for Taiwanese (LANG=t) hyphenated trs", () => {
     // tsia̍h has no hyphen; use a compound like "tsia̍h-pn̄g" to exercise the
     // rbspan counting branch for LANG=t.


### PR DESCRIPTION
Fixes #156

## 問題

兩岸辭典的大陸音顯示錯亂 —— 例如 [/~測度](https://www.moedict.tw/~測度) 會出現破碎的 `span>` 標籤，且注音／拼音的聲調符號飄到最右側（reporter 在 macOS Firefox 153 / Chrome 150 都能重現）。

## 根因

字典 API 的 `decodeLangPart`（`src/api/handleDictionaryAPI.ts`）會把 `b`/`p` 讀音欄位裡沿用自遠端資料的大陸音標記 `陸⃝`（`陸` + U+20DD COMBINING ENCLOSING CIRCLE）轉成地區標籤 markup：

```
ㄘㄜˋ ㄉㄨㄛˋ<br>陸⃝ㄘㄜˋ ㄉㄨㄛˊ
→ ㄘㄜˋ ㄉㄨㄛˋ<br><span class="regional part-of-speech">陸</span> ㄘㄜˋ ㄉㄨㄛˊ
```

但 `decorateRuby`（`src/utils/bopomofo-pinyin-utils.ts`）的讀音拆解邏輯仍以裸 `陸⃝` 標記為準。span 裡的 `/` 會誤觸 `陸.`、`[變|/]` 等 regex，於是：

- 吐出破碎的 `span>` 片段
- 把大陸音塞進 `<h1>` 的 `.alternative`（變／又音）區塊，並套上錯誤的「變」標籤，聲調符號因此飄到頁面最右側

## 修法（最小改動）

1. **`decorateRuby`**：開頭把地區標籤 span 折回 `X⃝` 標記，讓既有的下游規則照原本設計運作。修正後 `bAlt`/`pAlt` 不再被污染，`rubyData.pinyin`/`bopomofo` 為乾淨的大陸音、`cnSpecific` 正確標記。
2. **`DictionaryPage`**：在 `<h1>` 之後補上 `div.cn-specific.bopomofo > small.alternative.cn-specific`，讓遠端 legacy CSS 的「陸」標籤與底色生效，與 tooltip（`useRadicalTooltip`）既有的大陸音呈現一致。

## 測試

- 新增 `decorateRuby` 單元測試：餵入真實 API 的 span 形態，斷言無 `span>` 外洩且大陸音正確拆出。
- 新增 e2e 迴歸測試：`/~測度` 的 `.cn-specific` 區塊乾淨無殘留 markup。
- `tests/helpers/fixtures.ts` 補種 `pcck/44`（測度）供上述測試使用。
- 既有 2039 筆單元測試全數通過；`tsc`／lint 無新增問題；prod-parity allowlist（僅涵蓋台語 `.example` 幾何）不受影響。

## 視覺驗證（本機 Miniflare + 遠端 legacy CSS）

**修正前**：錯誤的「變」標籤 + `span> cdu` 殘留，聲調符號飄到頁面最右側。

**修正後**：正確的「陸」標籤，大陸音 `cèduó` / `ㄘㄜˋ ㄉㄨㄛˊ` 乾淨呈現於兩岸音框內。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0148sYYjXPDZ7RZkACfuixkX)_