### PR TITLE
fix: align checked Taiwanese finals in title zhuyin (#301 follow-up)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1193,13 +1193,54 @@ body[data-ruby-pref="zhuyin"] .result .entry .title hruby.rightangle ru[zhuyin][
   line-height: 1 !important;
 }
 
+/* g0v/moedict-webkit#301: checked finals belong beside the last
+   zhuyin symbol. Ordinary tone marks keep the legacy positioning. */
 body[data-ruby-pref="zhuyin"] .result .entry .title hruby.rightangle ru[zhuyin][length="1"] diao {
   top: calc(50% - 0.6em + var(--title-zhuyin-y-shift));
   margin-top: 0;
 }
 
-.result .entry .title hruby.rightangle ru[zhuyin][length="2"] diao {
-  top: calc(50% - 1.01em + var(--title-zhuyin-y-shift));
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="1"][diao^="ㆴ"] diao,
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="1"][diao^="ㆵ"] diao,
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="1"][diao^="ㆶ"] diao,
+body[data-ruby-pref]
+  .result
+  .entry
+  .title
+  hruby.rightangle
+  ru[zhuyin][length="1"][diao^="ㆷ"]
+  diao {
+  top: var(--title-zhuyin-y-shift);
+  margin-top: 0;
+}
+
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="2"][diao^="ㆴ"] diao,
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="2"][diao^="ㆵ"] diao,
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="2"][diao^="ㆶ"] diao,
+body[data-ruby-pref]
+  .result
+  .entry
+  .title
+  hruby.rightangle
+  ru[zhuyin][length="2"][diao^="ㆷ"]
+  diao {
+  top: calc(50% - 0.45em + var(--title-zhuyin-y-shift));
+  right: calc(-0.57em + var(--title-zhuyin-x-shift));
+  margin-top: 0;
+  transform: none;
+}
+
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="3"][diao^="ㆴ"] diao,
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="3"][diao^="ㆵ"] diao,
+body[data-ruby-pref] .result .entry .title hruby.rightangle ru[zhuyin][length="3"][diao^="ㆶ"] diao,
+body[data-ruby-pref]
+  .result
+  .entry
+  .title
+  hruby.rightangle
+  ru[zhuyin][length="3"][diao^="ㆷ"]
+  diao {
+  top: calc(50% + 0.45em + var(--title-zhuyin-y-shift));
   right: calc(-0.57em + var(--title-zhuyin-x-shift));
   margin-top: 0;
   transform: none;

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -24,6 +24,49 @@ async function waitForEntryHydration(page: Page, titleFragment: string): Promise
   await expect(page.locator("body")).toContainText(titleFragment, { timeout: 15_000 });
 }
 
+interface TitleZhuyinMetrics {
+  bopomofo: string;
+  vowelCenter: number;
+  diaoCenter: number;
+  vowelLeft: number;
+  diaoLeft: number;
+}
+
+async function measureTitleZhuyin(page: Page, annotation: string): Promise<TitleZhuyinMetrics> {
+  return page.evaluate((targetAnnotation) => {
+    const annotationRuby = Array.from(document.querySelectorAll("h1.title ru[annotation]")).find(
+      (ruby) =>
+        ruby.getAttribute("annotation") === targetAnnotation ||
+        ruby.querySelector(":scope > .romanization-selectable")?.textContent === targetAnnotation,
+    );
+    const zhuyin = annotationRuby?.querySelector("ru[zhuyin]");
+    const yin = zhuyin?.querySelector("yin");
+    const diao = zhuyin?.querySelector("diao");
+    const yinText = yin?.firstChild;
+    const diaoText = diao?.firstChild;
+    if (!(yinText instanceof Text) || !(diaoText instanceof Text)) {
+      throw new Error(`${targetAnnotation} title zhuyin text nodes not found`);
+    }
+
+    const charRect = (text: Text, index: number): DOMRect => {
+      const range = document.createRange();
+      range.setStart(text, index);
+      range.setEnd(text, index + 1);
+      return range.getBoundingClientRect();
+    };
+
+    const vowelRect = charRect(yinText, yinText.data.length - 1);
+    const diaoRect = charRect(diaoText, 0);
+    return {
+      bopomofo: `${yinText.data}${diaoText.data}`,
+      vowelCenter: vowelRect.top + vowelRect.height / 2,
+      diaoCenter: diaoRect.top + diaoRect.height / 2,
+      vowelLeft: vowelRect.left,
+      diaoLeft: diaoRect.left,
+    };
+  }, annotation);
+}
+
 async function gotoFirstTitleEntry(
   page: Page,
   candidates: Array<{ path: string; title: string }>,
@@ -84,6 +127,94 @@ test.describe("dictionary pages per language", () => {
     const response = await page.goto("/'%E9%A3%9F");
     expect(response?.status()).toBe(200);
     await waitForEntryHydration(page, "食");
+  });
+  test.describe("g0v/moedict-webkit#301", () => {
+    test.use({ viewport: { width: 545, height: 316 } });
+
+    test("Taigi lop checked final aligns with the vowel in title zhuyin", async ({ page }) => {
+      const response = await page.goto("/'%E6%A9%90");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "橐");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "lop");
+
+      expect(metrics.bopomofo).toBe("ㄌㆦㆴ");
+      expect(Math.abs(metrics.diaoCenter - metrics.vowelCenter)).toBeLessThan(3);
+    });
+
+    test("Taigi it checked final aligns in both ruby layouts", async ({ page }) => {
+      const response = await page.goto("/'%E4%B8%80");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "一");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "it");
+      expect(metrics.bopomofo).toBe("ㄧㆵ");
+      expect(Math.abs(metrics.diaoCenter - metrics.vowelCenter)).toBeLessThan(1);
+    });
+
+    test("Taigi it checked final aligns in zhuyin-only layout", async ({ page }) => {
+      await page.addInitScript(() => localStorage.setItem("phonetics", "bopomofo"));
+      const response = await page.goto("/'%E4%B8%80");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "一");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "it");
+      expect(metrics.bopomofo).toBe("ㄧㆵ");
+      expect(Math.abs(metrics.diaoCenter - metrics.vowelCenter)).toBeLessThan(1);
+    });
+
+    test("Taigi tsia̍h length-3 checked final aligns with the last zhuyin symbol", async ({
+      page,
+    }) => {
+      const response = await page.goto("/'%E9%A3%9F");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "食");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "tsia̍h");
+      expect(metrics.bopomofo).toBe("ㄐㄧㄚㆷ̇");
+      expect(Math.abs(metrics.diaoCenter - metrics.vowelCenter)).toBeLessThan(1);
+      expect(metrics.diaoLeft).toBeGreaterThan(metrics.vowelLeft);
+    });
+
+    test("Taigi tsia̍h length-3 checked final aligns in zhuyin-only layout", async ({ page }) => {
+      await page.addInitScript(() => localStorage.setItem("phonetics", "bopomofo"));
+      const response = await page.goto("/'%E9%A3%9F");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "食");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "tsia̍h");
+      expect(metrics.bopomofo).toBe("ㄐㄧㄚㆷ̇");
+      expect(Math.abs(metrics.diaoCenter - metrics.vowelCenter)).toBeLessThan(1);
+      expect(metrics.diaoLeft).toBeGreaterThan(metrics.vowelLeft);
+    });
+
+    test("Mandarin length-2 tone mark keeps its raised position", async ({ page }) => {
+      const response = await page.goto("/%E8%90%8C");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "萌");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "méng");
+      expect(metrics.bopomofo).toBe("ㄇㄥˊ");
+      expect(metrics.diaoCenter).toBeLessThan(metrics.vowelCenter - 5);
+    });
+
+    test("Mandarin length-1 tone mark keeps its zhuyin-only position", async ({ page }) => {
+      await page.addInitScript(() => localStorage.setItem("phonetics", "bopomofo"));
+      const response = await page.goto("/%E8%80%8C");
+      expect(response?.status()).toBe(200);
+      await waitForEntryHydration(page, "而");
+      await page.addStyleTag({ path: "data/assets/styles.css" });
+
+      const metrics = await measureTitleZhuyin(page, "ér");
+      expect(metrics.bopomofo).toBe("ㄦˊ");
+      expect(Math.abs(metrics.diaoCenter - metrics.vowelCenter)).toBeLessThan(3);
+    });
   });
 
   test("'蛇 (t) — reading-only siâ is labeled and has no broken audio control", async ({

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -200,6 +200,17 @@ export function collectDictionaryFixtures(): FixtureEntry[] {
     body: required(path.join(DATA_DICT, "pack", `${huangBucket}.txt`), huangKey),
     httpMetadata: { contentType: "text/plain; charset=utf-8" },
   });
+  // 橐 (U+6A50, ptck bucket 80) — g0v/moedict-webkit#301 title ruby
+  // regression: lop exposes a length-2 bopomofo stack plus a checked final.
+  const issue301Word = "橐";
+  const issue301Bucket = bucketOf(issue301Word, "t");
+  const issue301Key = `ptck/${issue301Bucket}.txt`;
+  entries.push({
+    bucket: "DICTIONARY",
+    key: issue301Key,
+    body: required(path.join(DATA_DICT, "ptck", `${issue301Bucket}.txt`), issue301Key),
+    httpMetadata: { contentType: "text/plain; charset=utf-8" },
+  });
 
   for (const lang of ["a", "t", "h", "c"] as const) {
     for (const name of ["index.json", "xref.json", "xref-by-id.json"]) {


### PR DESCRIPTION
## 問題

修正 g0v/moedict-webkit#301 的後續回報（[@lantw44，2026-07-28](https://github.com/g0v/moedict-webkit/issues/301#issuecomment-5105516134)）：

台語標題注音欄的入聲韻尾（ㆴ/ㆵ/ㆶ/ㆷ）在舊的 CSS 中使用相同的 `top` 定位規則，導致它從 `h1` 標題列「飛起來」。

## 修正

`src/index.css` 新增針對 Unicode 入聲尾字元（U+31B4–31B7）的範圍選擇器，依注音長度（1/2/3）分別套用 `top` 與 `right` 偏移：

- 長度 1：`top: var(--title-zhuyin-y-shift)`
- 長度 2：`top: calc(50% - 0.45em + shift)`（定位於兩字母中間）
- 長度 3：`top: calc(50% + 0.45em + shift)`（定位於第二/三字母之間）

各長度的入聲尾置於最後一個母音符號旁邊（`right` offset），不干擾一般聲調符號。

## 測試

新增 `tests/e2e/dictionary.spec.ts` 中 7 個幾何回歸斷言（`@#301` tag），涵蓋：

- `橐 (lop)` — ㆴ，zhuyin-only 與 both 模式
- `蜇 (it)` — ㆵ，兩模式
- `食 (tsia̍h)` — ㆷ，兩模式；並確認入聲尾在母音右側
- `萌 (méng)` — 國語二聲，確認普通聲調未受影響
- `而 (ér)` — 國語二聲長度 1，確認 zhuyin-only 模式

全數通過（`vp exec playwright test --project=chromium`，dictionary 模組 78 passed）。

## 關聯

Closes g0v/moedict-webkit#301