### PR TITLE
docs(cache): clarify public-read and invalidation gates

### DIFF
--- a/src/api/r2-json-cache.ts
+++ b/src/api/r2-json-cache.ts
@@ -133,7 +133,8 @@ type R2JsonSourceOrEnv = R2JsonSource | DictionaryObjectFetchEnv;
 
 /**
  * Read text content of a dictionary R2 object, routing through the public
- * CDN zone cache when DICTIONARY_BASE_URL is configured.
+ * CDN zone cache only when DICTIONARY_BASE_URL is configured and
+ * DICTIONARY_PUBLIC_READS is explicitly set to "1".
  *
  * WHY: Direct R2 binding GETs (`env.DICTIONARY.get()`) are billed as Class B
  * operations per isolate per colo. Requesting objects via the public custom

--- a/src/utils/image-generation.ts
+++ b/src/utils/image-generation.ts
@@ -11,8 +11,9 @@ import {
 } from "./edge-object-cache";
 
 /**
- * Bump this version string whenever glyph SVG or font asset bytes are replaced in R2.
- * This invalidates the L2 colo cache keys.
+ * Bump this version string whenever glyph SVG or font asset objects are added,
+ * replaced, or removed in R2. This invalidates both positive entries and cached
+ * 404 sentinels in the L2 colo cache.
  */
 export const FONT_OBJECT_CACHE_VERSION = "1";
 


### PR DESCRIPTION
Follow-up to #161 addressing both Copilot review suggestions that landed after the squash merge.

- State that public dictionary reads require both `DICTIONARY_BASE_URL` and the explicit `DICTIONARY_PUBLIC_READS="1"` gate.
- State that `FONT_OBJECT_CACHE_VERSION` must be bumped when font/glyph objects are added, replaced, or removed because the L2 cache retains positive entries and 404 sentinels.

Validation: `vp check`; `git diff --check`. No runtime behavior changed.