### PR TITLE
feat(data): guard twblg pinned entries against upstream drift (#271)

### DIFF
--- a/.github/workflows/verify-twblg-pins.yml
+++ b/.github/workflows/verify-twblg-pins.yml
@@ -1,0 +1,49 @@
+name: Verify TWBLG Pins Upstream
+
+on:
+  schedule:
+    # Run weekly on Sundays at 03:00 UTC (11:00 Taiwan time)
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      update_verified:
+        description: "Update verified dates if all pins pass"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: verify-twblg-pins-upstream
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify TWBLG Pinned Entries Against MOE
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "24"
+          cache: true
+
+      - run: vp install --frozen-lockfile
+
+      - name: Run upstream network verifier
+        id: run-verifier
+        run: |
+          if [ "${{ inputs.update_verified }}" = "true" ]; then
+            vp run twblg-pins:verify-upstream --update-verified
+          else
+            vp run twblg-pins:verify-upstream
+          fi
+
+      - name: Failure explanation
+        if: failure()
+        run: |
+          echo "::error::Upstream TWBLG pin verification failed. Check the logs above for details."
+          echo "Outcomes guide:"
+          echo "  - (b) Content drift: Upstream MOE dictionary changed. Update or remove the pin in data/sources/twblg-overrides/pinned-no-definition.json."
+          echo "  - (c) Structure changed: Upstream page markup changed. Update parsing logic in scripts/lib/twblg-pins.mjs."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,14 @@ moedict-data（MOE 原始 dump）→ moedict-process（pack 產生器）
   才能加入的窄例外**——嚴禁未逐筆核實就批次回填其餘 500+ 詞目。指令：
   `vp run twblg-pins:inject`（寫入，冪等）、`vp run twblg-pins:check`
   （唯讀驗證，已接入 `vp run check:data` 的第 4 項檢查；缺漏或內容不符
-  皆會讓 `check:data` fail-closed）。manifest 刻意放在
+  皆會讓 `check:data` fail-closed）。每個 entry 必須記載 `source_entry_url`、
+  `source_search_url`、`source_note` 及 ISO YYYY-MM-DD `verified` 日期；
+  `twblg-pins:check` 與 `check:data` 會報告 pin 筆數與最舊 pin 年齡作為資訊性輸出。
+  **上游網路驗證**：`vp run twblg-pins:verify-upstream`（或搭配 `--update-verified`）
+  會向 sutian.moe.edu.tw 逐筆核對詞目、音讀、無義項 marker 與搜尋唯一性，
+  並明確區分「主張成立 (ok)」、「上游內容漂移 (content drift)」與「頁面結構改變 (structure changed)」。
+  **規則：此網路驗證指令絕不放進 PR/push CI**，由 GitHub Actions 每週排程（`.github/workflows/verify-twblg-pins.yml`）
+  與手動 `workflow_dispatch` 觸發。manifest 刻意放在
   `data/sources/twblg-overrides/`（不在 `data/dictionary/` 底下）——
   `commands/upload_dictionary.sh` 只同步固定白名單子目錄
   （`pack/pcck/phck/ptck`、`a/c/h/t`、`search-index`、`translation-data`、

--- a/commands/verify-twblg-pins-upstream.mjs
+++ b/commands/verify-twblg-pins-upstream.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Network verifier for hand-curated Taiwanese dictionary pins (twblg-overrides/pinned-no-definition.json).
+ *
+ * Verifies that upstream MOE dictionary pages (sutian.moe.edu.tw) still hold the claimed assertions:
+ *  1. Headword still present
+ *  2. Every recorded reading still present (including slash-separated alternates)
+ *  3. No-definition marker still holds (no "釋義" section has appeared)
+ *  4. Search returns exactly one "完全符合" result
+ *
+ * Distinguishes three distinct outcomes:
+ *  (a) claim still holds (ok)
+ *  (b) upstream CONTENT drifted (data wrong; pin needs update/removal)
+ *  (c) page STRUCTURE changed (verifier itself needs updating; NEVER report as ok)
+ *
+ * Usage:
+ *   vp run twblg-pins:verify-upstream
+ *   vp run twblg-pins:verify-upstream --update-verified
+ *
+ * EXPLICIT RULE: This network script is NEVER run in PR or push CI. It is for manual/scheduled invocation.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  DEFAULT_PINNED_MANIFEST_PATH,
+  REPO_ROOT,
+  validatePinnedManifest,
+  verifyEntryHtml,
+  verifySearchHtml,
+} from "../scripts/lib/twblg-pins.mjs";
+
+const USER_AGENT = "moedict-twblg-pins-verifier/1.0 (+https://github.com/g0v/moedict.tw)";
+
+export async function fetchUrl(url, fetchFn = globalThis.fetch) {
+  try {
+    const res = await fetchFn(url, {
+      headers: { "User-Agent": USER_AGENT },
+    });
+    if (!res.ok) {
+      return { ok: false, status: res.status, text: "", error: `HTTP ${res.status}` };
+    }
+    const text = await res.text();
+    return { ok: true, status: res.status, text };
+  } catch (err) {
+    return { ok: false, status: 0, text: "", error: err.message || String(err) };
+  }
+}
+
+export async function verifySinglePin(entry, fetchFn = globalThis.fetch) {
+  const details = [];
+
+  // Fetch entry URL
+  const entryRes = await fetchUrl(entry.source_entry_url, fetchFn);
+  if (!entryRes.ok) {
+    return {
+      title: entry.title,
+      entryUrl: entry.source_entry_url,
+      searchUrl: entry.source_search_url,
+      status: "fetch_error",
+      details: [`Failed to fetch source entry URL (${entry.source_entry_url}): ${entryRes.error}`],
+    };
+  }
+
+  // Fetch search URL
+  const searchRes = await fetchUrl(entry.source_search_url, fetchFn);
+  if (!searchRes.ok) {
+    return {
+      title: entry.title,
+      entryUrl: entry.source_entry_url,
+      searchUrl: entry.source_search_url,
+      status: "fetch_error",
+      details: [
+        `Failed to fetch source search URL (${entry.source_search_url}): ${searchRes.error}`,
+      ],
+    };
+  }
+
+  // Check entry HTML
+  const entryCheck = verifyEntryHtml(entryRes.text, entry.title, entry.T);
+  if (entryCheck.status === "structure_changed") {
+    return {
+      title: entry.title,
+      entryUrl: entry.source_entry_url,
+      searchUrl: entry.source_search_url,
+      status: "structure_changed",
+      details: entryCheck.mismatches,
+    };
+  }
+  if (entryCheck.status === "content_drift") {
+    details.push(...entryCheck.mismatches);
+  }
+
+  // Check search HTML
+  const searchCheck = verifySearchHtml(searchRes.text, entry.title);
+  if (searchCheck.status === "structure_changed") {
+    return {
+      title: entry.title,
+      entryUrl: entry.source_entry_url,
+      searchUrl: entry.source_search_url,
+      status: "structure_changed",
+      details: [...details, ...searchCheck.mismatches],
+    };
+  }
+  if (searchCheck.status === "content_drift") {
+    details.push(...searchCheck.mismatches);
+  }
+
+  if (details.length > 0) {
+    return {
+      title: entry.title,
+      entryUrl: entry.source_entry_url,
+      searchUrl: entry.source_search_url,
+      status: "content_drift",
+      details,
+    };
+  }
+
+  return {
+    title: entry.title,
+    entryUrl: entry.source_entry_url,
+    searchUrl: entry.source_search_url,
+    status: "ok",
+    details: [],
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const updateVerified = args.includes("--update-verified");
+  const manifestPath = DEFAULT_PINNED_MANIFEST_PATH;
+
+  console.log(`Loading manifest from ${path.relative(REPO_ROOT, manifestPath)}...`);
+  let rawJson;
+  try {
+    rawJson = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (err) {
+    console.error(`ERROR: Failed to read/parse manifest: ${err.message}`);
+    process.exit(1);
+  }
+
+  const { valid, errors, manifest } = validatePinnedManifest(rawJson);
+  if (!valid || !manifest) {
+    console.error(`ERROR: Manifest validation failed:`);
+    errors.forEach((err) => console.error(`  - ${err}`));
+    process.exit(1);
+  }
+
+  console.log(
+    `Verifying ${manifest.entries.length} pinned entry/entries against upstream source...`,
+  );
+
+  const reports = [];
+  let hasStructureChanged = false;
+  let hasContentDrift = false;
+  let hasFetchError = false;
+
+  for (const entry of manifest.entries) {
+    console.log(`\nVerifying pin: ${entry.title} (${entry.T})...`);
+    const report = await verifySinglePin(entry);
+    reports.push(report);
+
+    if (report.status === "ok") {
+      console.log(
+        `  [OK] Claim holds. Headword, readings, no-definition, and 1 search result verified.`,
+      );
+    } else if (report.status === "structure_changed") {
+      hasStructureChanged = true;
+      console.error(`  [STRUCTURE CHANGED] Verifier logic could not evaluate page structure:`);
+      report.details.forEach((d) => console.error(`    - ${d}`));
+    } else if (report.status === "content_drift") {
+      hasContentDrift = true;
+      console.error(`  [CONTENT DRIFT] Upstream data changed:`);
+      report.details.forEach((d) => console.error(`    - ${d}`));
+    } else if (report.status === "fetch_error") {
+      hasFetchError = true;
+      console.error(`  [FETCH ERROR] Failed to retrieve page:`);
+      report.details.forEach((d) => console.error(`    - ${d}`));
+    }
+  }
+
+  console.log("\n==========================================");
+  console.log("SUMMARY OF UPSTREAM PIN VERIFICATION");
+  console.log("==========================================");
+  console.log(`Total pins checked: ${reports.length}`);
+  console.log(`  Passed (claims hold):       ${reports.filter((r) => r.status === "ok").length}`);
+  console.log(
+    `  Content drift (data wrong): ${reports.filter((r) => r.status === "content_drift").length}`,
+  );
+  console.log(
+    `  Structure changed:          ${reports.filter((r) => r.status === "structure_changed").length}`,
+  );
+  console.log(
+    `  Fetch errors:               ${reports.filter((r) => r.status === "fetch_error").length}`,
+  );
+
+  const allPassed = !hasStructureChanged && !hasContentDrift && !hasFetchError;
+
+  if (updateVerified) {
+    if (allPassed) {
+      const todayIso = new Date().toISOString().slice(0, 10);
+      console.log(`\nAll pins passed. Updating 'verified' dates to ${todayIso}...`);
+      manifest.entries.forEach((e) => {
+        e.verified = todayIso;
+      });
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+      console.log(`Updated verified dates in ${path.relative(REPO_ROOT, manifestPath)}.`);
+    } else {
+      console.error(
+        `\n--update-verified requested, but verification FAILED. Verified dates were NOT updated.`,
+      );
+    }
+  }
+
+  if (!allPassed) {
+    console.error("\n[VERIFICATION FAILED]");
+    if (hasStructureChanged) {
+      console.error(
+        "  -> Outcome (c): Upstream page structure changed. The verifier script itself needs updating.",
+      );
+    }
+    if (hasContentDrift) {
+      console.error(
+        "  -> Outcome (b): Upstream content drifted. Our dictionary data is wrong and needs correction or pin removal.",
+      );
+    }
+    if (hasFetchError) {
+      console.error("  -> Network/HTTP error accessing upstream MOE dictionary.");
+    }
+    process.exit(1);
+  }
+
+  console.log("\nAll pinned entries successfully verified against upstream MOE dictionary.");
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/commands/verify-twblg-pins-upstream.mjs
+++ b/commands/verify-twblg-pins-upstream.mjs
@@ -22,6 +22,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   DEFAULT_PINNED_MANIFEST_PATH,
   REPO_ROOT,
@@ -233,7 +234,7 @@ async function main() {
   console.log("\nAll pinned entries successfully verified against upstream MOE dictionary.");
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain = Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   main().catch((err) => {
     console.error(err);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "smoke:sub-routes": "node scripts/smoke-sub-routes.mjs",
     "twblg-pins:inject": "python3 scripts/inject-twblg-pinned-entries.py data/sources/twblg-overrides/pinned-no-definition.json data/dictionary/ptck",
     "twblg-pins:check": "python3 scripts/inject-twblg-pinned-entries.py data/sources/twblg-overrides/pinned-no-definition.json data/dictionary/ptck --check",
+    "twblg-pins:verify-upstream": "node commands/verify-twblg-pins-upstream.mjs",
     "check:data": "node scripts/check-dictionary-data.mjs",
     "dictionary:inventory:update": "node scripts/check-dictionary-inventory.mjs --update",
     "check:css-ids": "node scripts/check-legacy-css-ids.mjs",

--- a/scripts/check-dictionary-data.mjs
+++ b/scripts/check-dictionary-data.mjs
@@ -43,7 +43,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
+import { getPinAgeSummary, validatePinnedManifest } from "./lib/twblg-pins.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");
 const DICT_DIR = path.join(REPO_ROOT, "data", "dictionary");
@@ -185,29 +185,45 @@ if (!existsSync(PINNED_MANIFEST)) {
       `— g0v/moedict-webkit#271 provenance would silently stop being verified`,
   );
 } else {
-  let manifest;
+  let rawJson;
   try {
-    manifest = JSON.parse(readFileSync(PINNED_MANIFEST, "utf8"));
+    rawJson = JSON.parse(readFileSync(PINNED_MANIFEST, "utf8"));
   } catch (e) {
     fail(`pinned no-definition manifest is not valid JSON: ${e.message}`);
   }
-  if (manifest) {
-    pinnedCheckedCount = Array.isArray(manifest.entries) ? manifest.entries.length : 0;
-    if (pinnedCheckedCount === 0) {
+  if (rawJson) {
+    const { valid, errors, manifest } = validatePinnedManifest(rawJson);
+    if (!valid || !manifest) {
       fail(
-        "pinned no-definition manifest has zero entries — expected at least " +
-          "the 長褲 (g0v/moedict-webkit#271) pin shipped with this repo",
+        `pinned no-definition manifest schema/provenance validation failed:\n` +
+          errors.map((err) => `  - ${err}`).join("\n"),
       );
     } else {
-      try {
-        execFileSync("python3", [INJECTOR, PINNED_MANIFEST, PTCK_DIR, "--check"], {
-          cwd: REPO_ROOT,
-          stdio: "pipe",
-          encoding: "utf8",
-        });
-      } catch (e) {
-        const output = [e.stdout, e.stderr].filter(Boolean).join("\n");
-        fail(`pinned no-definition manifest check failed:\n${output || e.message}`);
+      pinnedCheckedCount = manifest.entries.length;
+      if (pinnedCheckedCount === 0) {
+        fail(
+          "pinned no-definition manifest has zero entries — expected at least " +
+            "the 長褲 (g0v/moedict-webkit#271) pin shipped with this repo",
+        );
+      } else {
+        const ageSummary = getPinAgeSummary(manifest);
+        if (ageSummary.oldestDate !== null && ageSummary.oldestAgeDays !== null) {
+          console.log(
+            `[check-dictionary-data] Pinned no-definition age info: ` +
+              `${ageSummary.count} pin(s), oldest verified on ${ageSummary.oldestDate} ` +
+              `(${ageSummary.oldestTitle}, ${ageSummary.oldestAgeDays} days ago)`,
+          );
+        }
+        try {
+          execFileSync("python3", [INJECTOR, PINNED_MANIFEST, PTCK_DIR, "--check"], {
+            cwd: REPO_ROOT,
+            stdio: "pipe",
+            encoding: "utf8",
+          });
+        } catch (e) {
+          const output = [e.stdout, e.stderr].filter(Boolean).join("\n");
+          fail(`pinned no-definition manifest check failed:\n${output || e.message}`);
+        }
       }
     }
   }

--- a/scripts/inject-twblg-pinned-entries.py
+++ b/scripts/inject-twblg-pinned-entries.py
@@ -66,10 +66,24 @@ direction (deleted entry, hand-edited entry) is caught, not skipped.
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
+import re
 import sys
 import unicodedata
+
+ISO_DATE_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$")
+
+
+def is_valid_iso_date(date_str: str) -> bool:
+    if not isinstance(date_str, str) or not ISO_DATE_RE.match(date_str):
+        return False
+    try:
+        datetime.date.fromisoformat(date_str)
+        return True
+    except ValueError:
+        return False
 
 
 def bucket_of(title: str) -> int:
@@ -119,9 +133,23 @@ def load_manifest(path: str) -> list[dict]:
         manifest = json.load(f)
     entries = manifest.get("entries", [])
     for entry in entries:
-        for required_key in ("title", "T", "source_entry_url", "source_search_url"):
-            if not entry.get(required_key):
-                raise ValueError(f"Manifest entry missing {required_key!r}: {entry!r}")
+        for required_key in (
+            "title",
+            "T",
+            "source_entry_url",
+            "source_search_url",
+            "source_note",
+            "verified",
+        ):
+            val = entry.get(required_key)
+            if not isinstance(val, str) or not val.strip():
+                raise ValueError(
+                    f"Manifest entry missing or invalid required string field {required_key!r}: {entry!r}"
+                )
+        if not is_valid_iso_date(entry["verified"]):
+            raise ValueError(
+                f"Manifest entry has invalid ISO verified date {entry['verified']!r}: {entry!r}"
+            )
     return entries
 
 
@@ -354,6 +382,17 @@ def main():
     print(f"  Already correct:   {ok_existing}")
     print(f"  Missing:           {missing}")
     print(f"  Mismatched:        {mismatched}")
+    if entries:
+        today = datetime.date.today()
+        ages = []
+        for e in entries:
+            y, m, d = map(int, e["verified"].split("-"))
+            v_date = datetime.date(y, m, d)
+            age_days = (today - v_date).days
+            ages.append((age_days, e["verified"], e["title"]))
+        ages.sort(reverse=True)
+        oldest_days, oldest_date, oldest_title = ages[0]
+        print(f"  Pin age info:      {len(entries)} pins, oldest verified on {oldest_date} ({oldest_title}, {oldest_days} days ago)")
     if args.dry_run and not args.check:
         print("\n[DRY RUN — no files written]")
 

--- a/scripts/lib/twblg-pins.mjs
+++ b/scripts/lib/twblg-pins.mjs
@@ -132,6 +132,10 @@ export function getPinAgeSummary(manifest, now = new Date()) {
   };
 }
 
+export function normalizeWhitespace(s) {
+  return s.normalize("NFC").replace(/\s+/g, " ").trim();
+}
+
 /**
  * Checks an entry HTML page against expected title, reading(s), and no-definition condition.
  * @param {string} html
@@ -141,38 +145,52 @@ export function getPinAgeSummary(manifest, now = new Date()) {
  */
 export function verifyEntryHtml(html, expectedTitle, expectedT) {
   const mismatches = [];
+  const normHtml = html.normalize("NFC");
+  const normTitle = expectedTitle.normalize("NFC");
 
-  const hasH1 = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i.test(html);
-  const hasMain = /<main\b/i.test(html) || /class="[^"]*container/i.test(html);
-  if (!hasH1 || !hasMain) {
+  // 1. Structure check: <main> and <h1> must be present
+  const hasMain = /<main\b/i.test(normHtml);
+  const h1Match = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i.exec(normHtml);
+  if (!hasMain || !h1Match) {
     return {
       status: "structure_changed",
-      mismatches: ["Entry page structure changed: missing <h1...>" + (!hasH1 ? " and <main>" : "")],
+      mismatches: ["Entry page structure changed: missing <main> or <h1> element"],
     };
   }
 
-  const h1Match = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i.exec(html);
-  const h1Text = h1Match ? h1Match[1].replace(/<[^>]+>/g, "").trim() : "";
-  if (h1Text !== expectedTitle) {
-    mismatches.push(`Headword mismatch: expected "${expectedTitle}", got "${h1Text}"`);
+  // 2. Headword match
+  const h1Text = h1Match[1].replace(/<[^>]+>/g, "").trim();
+  if (h1Text !== normTitle) {
+    mismatches.push(`Headword mismatch: expected "${normTitle}", got "${h1Text}"`);
   }
 
-  const expectedReadings = expectedT.split("/").map((r) => r.trim().normalize("NFC"));
+  // 3. Pronunciation list header structure check
+  const readingBlockMatch = normHtml.match(
+    /<header[\s\S]*?<ul\b[^>]*class="[^"]*list-inline[^"]*"[\s\S]*?<\/header>/i,
+  );
+  if (!readingBlockMatch) {
+    return {
+      status: "structure_changed",
+      mismatches: ["Entry page structure changed: could not locate pronunciation header list"],
+    };
+  }
 
+  // 4. Check all expected readings (NFC normalized)
+  const expectedReadings = expectedT.split("/").map((r) => r.trim().normalize("NFC"));
   for (const reading of expectedReadings) {
-    const normHtml = html.normalize("NFC");
     if (!normHtml.includes(reading)) {
-      mismatches.push(`Reading missing from page: expected reading "${reading}" not found`);
+      mismatches.push(`Reading missing from entry page: expected reading "${reading}" not found`);
     }
   }
 
+  // 5. Negative assertion: entry page must NOT contain a definition section
   const hasDefinitionSection =
-    /id=["']釋義["']/i.test(html) ||
-    /<h2\b[^>]*>\s*釋義\s*<\/h2>/i.test(html) ||
-    /class="[^"]*subok-pt[^"]*"[^>]*>\s*釋義\s*<\/h2>/i.test(html);
+    /id=["']釋義["']/i.test(normHtml) ||
+    /<h2\b[^>]*>\s*釋義\s*<\/h2>/i.test(normHtml) ||
+    /class="[^"]*subok-pt[^"]*"[^>]*>\s*釋義\s*<\/h2>/i.test(normHtml);
 
   if (hasDefinitionSection) {
-    mismatches.push("Definition appeared on page (section '釋義' found)");
+    mismatches.push('Definition section appeared on entry page (section "釋義" found)');
   }
 
   if (mismatches.length > 0) {
@@ -183,29 +201,30 @@ export function verifyEntryHtml(html, expectedTitle, expectedT) {
 }
 
 /**
- * Checks a search result HTML page against expected exact match count (1).
+ * Checks a search result HTML page against expected exact match count (1) and positive no-definition marker.
  * @param {string} html
  * @param {string} expectedTitle
  * @returns {{ status: "ok" | "content_drift" | "structure_changed", mismatches: string[] }}
  */
 export function verifySearchHtml(html, expectedTitle) {
+  const mismatches = [];
   const normHtml = html.normalize("NFC");
   const normTitle = expectedTitle.normalize("NFC");
 
-  const matchCount = normHtml.match(/完全符合\s*「?([^」"'\s]+)」?\s*有\s*(\d+)\s*筆/);
-  if (!matchCount) {
+  // 1. Structure check: exact match count
+  const countMatch = normHtml.match(/完全符合\s*「?([^」"'\s]+)」?\s*有\s*(\d+)\s*筆/);
+  if (!countMatch) {
     return {
       status: "structure_changed",
       mismatches: [
-        `Search page structure changed: could not find "完全符合 ... 有 X 筆" summary pattern`,
+        "Search page structure changed: could not find '完全符合 ... 有 X 筆' summary pattern",
       ],
     };
   }
 
-  const reportedTitle = matchCount[1].trim();
-  const count = parseInt(matchCount[2], 10);
+  const reportedTitle = countMatch[1].trim();
+  const count = parseInt(countMatch[2], 10);
 
-  const mismatches = [];
   if (reportedTitle !== normTitle) {
     mismatches.push(
       `Search target title mismatch: expected "${normTitle}", found "${reportedTitle}" in search header`,
@@ -214,6 +233,26 @@ export function verifySearchHtml(html, expectedTitle) {
   if (count !== 1) {
     mismatches.push(
       `Search match count changed: expected exactly 1 "完全符合" result for "${normTitle}", got ${count}`,
+    );
+  }
+
+  // 2. Positive assertion: definition row in search result table
+  const defRowMatch = normHtml.match(
+    /<tr>\s*<th>\s*釋義\s*<\/th>\s*<td>([\s\S]*?)<\/td>\s*<\/tr>/i,
+  );
+  if (!defRowMatch) {
+    return {
+      status: "structure_changed",
+      mismatches: [
+        "Search page structure changed: could not find definition row (<tr><th>釋義</th><td>...) in search result table",
+      ],
+    };
+  }
+
+  const defText = normalizeWhitespace(defRowMatch[1].replace(/<[^>]+>/g, ""));
+  if (!defText.includes("無義項")) {
+    mismatches.push(
+      `Search page definition row does not carry no-definition marker: got "${defText}"`,
     );
   }
 

--- a/scripts/lib/twblg-pins.mjs
+++ b/scripts/lib/twblg-pins.mjs
@@ -165,9 +165,16 @@ export function verifyEntryHtml(html, expectedTitle, expectedT) {
   }
 
   // 3. Pronunciation list header structure check
-  const readingBlockMatch = normHtml.match(
-    /<header[\s\S]*?<ul\b[^>]*class="[^"]*list-inline[^"]*"[\s\S]*?<\/header>/i,
-  );
+  const mainMatch = normHtml.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+  const mainHtml = mainMatch ? mainMatch[1] : normHtml;
+  const readingBlockMatch =
+    mainHtml.match(
+      /<header\b[^>]*>[\s\S]*?<ul\b[^>]*class="[^"]*list-inline[^"]*"[\s\S]*?<\/header>/i,
+    ) ||
+    normHtml.match(
+      /<header\b[^>]*>[\s\S]*?<ul\b[^>]*class="[^"]*list-inline[^"]*"[\s\S]*?<\/header>/i,
+    );
+
   if (!readingBlockMatch) {
     return {
       status: "structure_changed",
@@ -175,11 +182,37 @@ export function verifyEntryHtml(html, expectedTitle, expectedT) {
     };
   }
 
-  // 4. Check all expected readings (NFC normalized)
+  const readingBlockText = readingBlockMatch[0];
+
+  // 4. Check expected readings (NFC normalized):
+  // Main reading must reside in the pronunciation header block.
+  // Alternate readings (if any) must reside in the "又唸作" section.
   const expectedReadings = expectedT.split("/").map((r) => r.trim().normalize("NFC"));
-  for (const reading of expectedReadings) {
-    if (!normHtml.includes(reading)) {
-      mismatches.push(`Reading missing from entry page: expected reading "${reading}" not found`);
+  const [mainReading, ...alternateReadings] = expectedReadings;
+
+  if (mainReading && !readingBlockText.includes(mainReading)) {
+    mismatches.push(
+      `Main reading missing from pronunciation header: expected "${mainReading}" not found in header`,
+    );
+  }
+
+  if (alternateReadings.length > 0) {
+    const altSectionMatch =
+      normHtml.match(
+        /<section\b[^>]*>[\s\S]*?(?:id=["']又唸作["']|<h2\b[^>]*>\s*又唸作\s*<\/h2>)[\s\S]*?<\/section>/i,
+      ) || normHtml.match(/(?:<div|<section)\b[^>]*id=["']又唸作["'][\s\S]*?<\/(?:div|section)>/i);
+
+    if (!altSectionMatch) {
+      mismatches.push('Alternate reading section ("又唸作") not found on entry page');
+    } else {
+      const altSectionText = altSectionMatch[0];
+      for (const altReading of alternateReadings) {
+        if (!altSectionText.includes(altReading)) {
+          mismatches.push(
+            `Alternate reading missing from "又唸作" section: expected "${altReading}" not found`,
+          );
+        }
+      }
     }
   }
 

--- a/scripts/lib/twblg-pins.mjs
+++ b/scripts/lib/twblg-pins.mjs
@@ -1,0 +1,225 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "../..");
+export const DEFAULT_PINNED_MANIFEST_PATH = path.join(
+  REPO_ROOT,
+  "data",
+  "sources",
+  "twblg-overrides",
+  "pinned-no-definition.json",
+);
+
+/**
+ * Validates ISO YYYY-MM-DD date format and sanity checks month/day/year.
+ * @param {unknown} dateStr
+ * @returns {boolean}
+ */
+export function isValidIsoDate(dateStr) {
+  if (typeof dateStr !== "string") return false;
+  const match = /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.exec(dateStr);
+  if (!match) return false;
+  const year = parseInt(match[1], 10);
+  const month = parseInt(match[2], 10);
+  const day = parseInt(match[3], 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
+
+/**
+ * @param {unknown} manifest
+ * @returns {{ valid: boolean, errors: string[], manifest?: any }}
+ */
+export function validatePinnedManifest(manifest) {
+  const errors = [];
+  if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) {
+    return { valid: false, errors: ["Manifest root must be an object"] };
+  }
+  const entries = manifest.entries;
+  if (!Array.isArray(entries)) {
+    return { valid: false, errors: ['Manifest "entries" must be an array'] };
+  }
+
+  const validatedEntries = [];
+  entries.forEach((entry, idx) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      errors.push(`Entry #${idx} is not an object`);
+      return;
+    }
+    const e = entry;
+    const requiredFields = [
+      "title",
+      "T",
+      "source_entry_url",
+      "source_search_url",
+      "source_note",
+      "verified",
+    ];
+
+    for (const field of requiredFields) {
+      if (typeof e[field] !== "string" || !e[field].trim()) {
+        errors.push(
+          `Entry #${idx} (${e.title ?? "unknown"}) missing or empty required string field "${field}"`,
+        );
+      }
+    }
+
+    if (typeof e.verified === "string" && e.verified.trim()) {
+      if (!isValidIsoDate(e.verified)) {
+        errors.push(
+          `Entry #${idx} (${e.title ?? "unknown"}) "verified" date "${e.verified}" is not a valid ISO YYYY-MM-DD date`,
+        );
+      }
+    }
+
+    if (errors.length === 0) {
+      validatedEntries.push(e);
+    }
+  });
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    errors: [],
+    manifest: manifest,
+  };
+}
+
+export function calculatePinAge(verifiedDateStr, now = new Date()) {
+  const verified = new Date(`${verifiedDateStr}T00:00:00Z`);
+  const diffTime = now.getTime() - verified.getTime();
+  return Math.max(0, Math.floor(diffTime / (1000 * 60 * 60 * 24)));
+}
+
+export function getPinAgeSummary(manifest, now = new Date()) {
+  if (!manifest.entries || manifest.entries.length === 0) {
+    return { count: 0, oldestDate: null, oldestAgeDays: null, oldestTitle: null };
+  }
+
+  let oldestEntry = null;
+  let oldestDays = -1;
+
+  for (const entry of manifest.entries) {
+    if (entry.verified && isValidIsoDate(entry.verified)) {
+      const age = calculatePinAge(entry.verified, now);
+      if (age > oldestDays) {
+        oldestDays = age;
+        oldestEntry = entry;
+      }
+    }
+  }
+
+  if (!oldestEntry) {
+    return {
+      count: manifest.entries.length,
+      oldestDate: null,
+      oldestAgeDays: null,
+      oldestTitle: null,
+    };
+  }
+
+  return {
+    count: manifest.entries.length,
+    oldestDate: oldestEntry.verified,
+    oldestAgeDays: oldestDays,
+    oldestTitle: oldestEntry.title,
+  };
+}
+
+/**
+ * Checks an entry HTML page against expected title, reading(s), and no-definition condition.
+ * @param {string} html
+ * @param {string} expectedTitle
+ * @param {string} expectedT
+ * @returns {{ status: "ok" | "content_drift" | "structure_changed", mismatches: string[] }}
+ */
+export function verifyEntryHtml(html, expectedTitle, expectedT) {
+  const mismatches = [];
+
+  const hasH1 = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i.test(html);
+  const hasMain = /<main\b/i.test(html) || /class="[^"]*container/i.test(html);
+  if (!hasH1 || !hasMain) {
+    return {
+      status: "structure_changed",
+      mismatches: ["Entry page structure changed: missing <h1...>" + (!hasH1 ? " and <main>" : "")],
+    };
+  }
+
+  const h1Match = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i.exec(html);
+  const h1Text = h1Match ? h1Match[1].replace(/<[^>]+>/g, "").trim() : "";
+  if (h1Text !== expectedTitle) {
+    mismatches.push(`Headword mismatch: expected "${expectedTitle}", got "${h1Text}"`);
+  }
+
+  const expectedReadings = expectedT.split("/").map((r) => r.trim().normalize("NFC"));
+
+  for (const reading of expectedReadings) {
+    const normHtml = html.normalize("NFC");
+    if (!normHtml.includes(reading)) {
+      mismatches.push(`Reading missing from page: expected reading "${reading}" not found`);
+    }
+  }
+
+  const hasDefinitionSection =
+    /id=["']釋義["']/i.test(html) ||
+    /<h2\b[^>]*>\s*釋義\s*<\/h2>/i.test(html) ||
+    /class="[^"]*subok-pt[^"]*"[^>]*>\s*釋義\s*<\/h2>/i.test(html);
+
+  if (hasDefinitionSection) {
+    mismatches.push("Definition appeared on page (section '釋義' found)");
+  }
+
+  if (mismatches.length > 0) {
+    return { status: "content_drift", mismatches };
+  }
+
+  return { status: "ok", mismatches: [] };
+}
+
+/**
+ * Checks a search result HTML page against expected exact match count (1).
+ * @param {string} html
+ * @param {string} expectedTitle
+ * @returns {{ status: "ok" | "content_drift" | "structure_changed", mismatches: string[] }}
+ */
+export function verifySearchHtml(html, expectedTitle) {
+  const normHtml = html.normalize("NFC");
+  const normTitle = expectedTitle.normalize("NFC");
+
+  const matchCount = normHtml.match(/完全符合\s*「?([^」"'\s]+)」?\s*有\s*(\d+)\s*筆/);
+  if (!matchCount) {
+    return {
+      status: "structure_changed",
+      mismatches: [
+        `Search page structure changed: could not find "完全符合 ... 有 X 筆" summary pattern`,
+      ],
+    };
+  }
+
+  const reportedTitle = matchCount[1].trim();
+  const count = parseInt(matchCount[2], 10);
+
+  const mismatches = [];
+  if (reportedTitle !== normTitle) {
+    mismatches.push(
+      `Search target title mismatch: expected "${normTitle}", found "${reportedTitle}" in search header`,
+    );
+  }
+  if (count !== 1) {
+    mismatches.push(
+      `Search match count changed: expected exactly 1 "完全符合" result for "${normTitle}", got ${count}`,
+    );
+  }
+
+  if (mismatches.length > 0) {
+    return { status: "content_drift", mismatches };
+  }
+
+  return { status: "ok", mismatches: [] };
+}

--- a/scripts/lib/twblg-pins.mjs
+++ b/scripts/lib/twblg-pins.mjs
@@ -152,9 +152,13 @@ export function verifyEntryHtml(html, expectedTitle, expectedT) {
   const hasMain = /<main\b/i.test(normHtml);
   const h1Match = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i.exec(normHtml);
   if (!hasMain || !h1Match) {
+    const missing = [];
+    if (!hasMain) missing.push("<main>");
+    if (!h1Match) missing.push("<h1>");
+    const noun = missing.length === 1 ? "element" : "elements";
     return {
       status: "structure_changed",
-      mismatches: ["Entry page structure changed: missing <main> or <h1> element"],
+      mismatches: [`Entry page structure changed: missing ${missing.join(" and ")} ${noun}`],
     };
   }
 
@@ -245,7 +249,7 @@ export function verifySearchHtml(html, expectedTitle) {
   const normTitle = expectedTitle.normalize("NFC");
 
   // 1. Structure check: exact match count
-  const countMatch = normHtml.match(/完全符合\s*「?([^」"'\s]+)」?\s*有\s*(\d+)\s*筆/);
+  const countMatch = normHtml.match(/完全符合\s*「([^」]+)」\s*有\s*(\d+)\s*筆/);
   if (!countMatch) {
     return {
       status: "structure_changed",

--- a/tests/fixtures/twblg-upstream/entry-drift-alt-reading-mismatched.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-alt-reading-mismatched.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="zh-hant-tw">
+  <head>
+    <title>芭蕾-詞目-教育部臺灣台語常用詞辭典</title>
+  </head>
+  <body>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">芭蕾</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>pa-lê</span></li>
+              </ul>
+            </div>
+          </header>
+          <section class="row">
+            <div class="col-12 col-md-2" id="又唸作">
+              <h2 class="bg-dark bg-opacity-10 h5 px-2 pb-1 subok-pt rounded">又唸作</h2>
+            </div>
+            <div class="col-12 col-md-10">
+              <ul class="list-inline ms-2 ms-md-0">
+                <li class="list-inline-item me-0 tng-divider">
+                  <ul class="d-inline-block ps-0">
+                    <li class="list-inline-item me-0 slash-divider"><span>khu-le</span></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-drift-alt-reading-missing-section.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-alt-reading-missing-section.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="zh-hant-tw">
+  <head>
+    <title>芭蕾-詞目-教育部臺灣台語常用詞辭典</title>
+  </head>
+  <body>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">芭蕾</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>pa-lê</span></li>
+              </ul>
+            </div>
+          </header>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-drift-headword-mismatch.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-headword-mismatch.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>短褲 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="container">
+      <main>
+        <h1>短褲</h1>
+        <div class="reading-box">
+          <span>té-khòo</span>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-drift-headword-mismatch.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-headword-mismatch.html
@@ -1,16 +1,22 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>短褲 - 臺灣閩南語常用詞辭典</title>
+    <title>短褲-詞目-教育部臺灣台語常用詞辭典</title>
   </head>
   <body>
-    <div class="container">
-      <main>
-        <h1>短褲</h1>
-        <div class="reading-box">
-          <span>té-khòo</span>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">短褲</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>té-khòo</span></li>
+              </ul>
+            </div>
+          </header>
         </div>
-      </main>
-    </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/entry-drift-main-reading-only-in-body.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-main-reading-only-in-body.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh-hant-tw">
+  <head>
+    <title>長褲-詞目-教育部臺灣台語常用詞辭典 tn̂g-khòo</title>
+  </head>
+  <body>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">長褲</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>tshu-tsoo</span></li>
+              </ul>
+            </div>
+          </header>
+          <div class="corpus-examples">
+            <p>Usage example mentioning tn̂g-khòo elsewhere in the document</p>
+          </div>
+        </div>
+      </div>
+    </main>
+    <footer>
+      <span>Site footer with tn̂g-khòo</span>
+    </footer>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-drift-reading-changed.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-reading-changed.html
@@ -1,16 +1,22 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>芭蕾 - 臺灣閩南語常用詞辭典</title>
+    <title>芭蕾-詞目-教育部臺灣台語常用詞辭典</title>
   </head>
   <body>
-    <div class="container">
-      <main>
-        <h1>芭蕾</h1>
-        <div class="reading-box">
-          <span>pa-lê</span>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">芭蕾</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>pa-lê</span></li>
+              </ul>
+            </div>
+          </header>
         </div>
-      </main>
-    </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/entry-drift-reading-changed.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-reading-changed.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>芭蕾 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="container">
+      <main>
+        <h1>芭蕾</h1>
+        <div class="reading-box">
+          <span>pa-lê</span>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-drift-with-definition.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-with-definition.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>長褲 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="container">
+      <main>
+        <h1>長褲</h1>
+        <div class="reading-box">
+          <span>tn̂g-khòo</span>
+        </div>
+        <section id="釋義">
+          <h2>釋義</h2>
+          <p>褲管長及腳踝的褲子。</p>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-drift-with-definition.html
+++ b/tests/fixtures/twblg-upstream/entry-drift-with-definition.html
@@ -1,20 +1,30 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>長褲 - 臺灣閩南語常用詞辭典</title>
+    <title>長褲-詞目-教育部臺灣台語常用詞辭典</title>
   </head>
   <body>
-    <div class="container">
-      <main>
-        <h1>長褲</h1>
-        <div class="reading-box">
-          <span>tn̂g-khòo</span>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">長褲</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>tn̂g-khòo</span></li>
+              </ul>
+            </div>
+          </header>
+          <section class="row">
+            <div class="col-12 col-md-2" id="釋義">
+              <h2 class="bg-dark bg-opacity-10 h5 px-2 pb-1 subok-pt rounded">釋義</h2>
+            </div>
+            <div class="col-12 col-md-10">
+              <p>褲管長及腳踝的褲子。</p>
+            </div>
+          </section>
         </div>
-        <section id="釋義">
-          <h2>釋義</h2>
-          <p>褲管長及腳踝的褲子。</p>
-        </section>
-      </main>
-    </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/entry-structure-missing-h1.html
+++ b/tests/fixtures/twblg-upstream/entry-structure-missing-h1.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>Error</title>
+  </head>
+  <body>
+    <div class="error-page">
+      <p>Page not found</p>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-structure-missing-reading-header.html
+++ b/tests/fixtures/twblg-upstream/entry-structure-missing-reading-header.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="zh-hant-tw">
   <head>
-    <title>Error</title>
+    <title>長褲</title>
   </head>
   <body>
     <main>
-      <p>Page content without h1</p>
+      <h1>長褲</h1>
     </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/entry-valid-multi-reading.html
+++ b/tests/fixtures/twblg-upstream/entry-valid-multi-reading.html
@@ -1,14 +1,36 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>芭蕾 - 臺灣閩南語常用詞辭典</title>
+    <title>芭蕾-詞目-教育部臺灣台語常用詞辭典</title>
   </head>
   <body>
-    <div class="container">
-      <main>
-        <h1>芭蕾</h1>
-        <div class="reading-box"><span>pa-lê</span> / <span>pa-lé</span></div>
-      </main>
-    </div>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">芭蕾</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>pa-lê</span></li>
+              </ul>
+            </div>
+          </header>
+          <section class="row">
+            <div class="col-12 col-md-2" id="又唸作">
+              <h2 class="bg-dark bg-opacity-10 h5 px-2 pb-1 subok-pt rounded">又唸作</h2>
+            </div>
+            <div class="col-12 col-md-10">
+              <ul class="list-inline ms-2 ms-md-0">
+                <li class="list-inline-item me-0 tng-divider">
+                  <ul class="d-inline-block ps-0">
+                    <li class="list-inline-item me-0 slash-divider"><span>pa-lé</span></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/entry-valid-multi-reading.html
+++ b/tests/fixtures/twblg-upstream/entry-valid-multi-reading.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>芭蕾 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="container">
+      <main>
+        <h1>芭蕾</h1>
+        <div class="reading-box"><span>pa-lê</span> / <span>pa-lé</span></div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-valid-no-def.html
+++ b/tests/fixtures/twblg-upstream/entry-valid-no-def.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>長褲 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="container">
+      <main>
+        <h1>長褲</h1>
+        <div class="reading-box">
+          <span>tn̂g-khòo</span>
+        </div>
+        <div class="notes">
+          <p>附錄：本詞目僅收錄音讀，無釋義。</p>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/entry-valid-no-def.html
+++ b/tests/fixtures/twblg-upstream/entry-valid-no-def.html
@@ -1,19 +1,27 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>長褲 - 臺灣閩南語常用詞辭典</title>
+    <title>長褲-詞目-教育部臺灣台語常用詞辭典</title>
   </head>
   <body>
-    <div class="container">
-      <main>
-        <h1>長褲</h1>
-        <div class="reading-box">
-          <span>tn̂g-khòo</span>
+    <main class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6 py-lg-3">
+          <header>
+            <h1 class="d-inline-block">長褲</h1>
+            <div class="d-flex flex-row align-items-baseline">
+              <ul class="fs-4 fw-bold list-inline">
+                <li class="list-inline-item me-0 slash-divider"><span>tn̂g-khòo</span></li>
+              </ul>
+            </div>
+          </header>
+          <section class="row">
+            <div class="col-12 col-md-2" id="分類">
+              <h2 class="bg-dark bg-opacity-10 h5 px-2 pb-1 subok-pt rounded">分類</h2>
+            </div>
+          </section>
         </div>
-        <div class="notes">
-          <p>附錄：本詞目僅收錄音讀，無釋義。</p>
-        </div>
-      </main>
-    </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/search-drift-def-appeared.html
+++ b/tests/fixtures/twblg-upstream/search-drift-def-appeared.html
@@ -5,12 +5,12 @@
   </head>
   <body>
     <main class="container-fluid">
-      <p class="text-secondary mb-0">完全符合 「長褲」 有2筆</p>
+      <p class="text-secondary mb-0">完全符合 「長褲」 有1筆</p>
       <table class="table">
         <tbody>
           <tr>
             <th>釋義</th>
-            <td><span>（臺華共同詞 ，無義項）</span></td>
+            <td><span>褲管長及腳踝的褲子。</span></td>
           </tr>
         </tbody>
       </table>

--- a/tests/fixtures/twblg-upstream/search-drift-multiple-matches.html
+++ b/tests/fixtures/twblg-upstream/search-drift-multiple-matches.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>搜尋結果 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="search-result">
+      <p class="summary">搜尋結果：完全符合「長褲」有 2 筆</p>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/search-drift-zero-matches.html
+++ b/tests/fixtures/twblg-upstream/search-drift-zero-matches.html
@@ -1,11 +1,19 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>搜尋結果 - 臺灣閩南語常用詞辭典</title>
+    <title>長褲-用臺灣台語查詞目</title>
   </head>
   <body>
-    <div class="search-result">
-      <p class="summary">搜尋結果：完全符合「長褲」有 0 筆</p>
-    </div>
+    <main class="container-fluid">
+      <p class="text-secondary mb-0">完全符合 「長褲」 有0筆</p>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th>釋義</th>
+            <td><span>（臺華共同詞 ，無義項）</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/search-drift-zero-matches.html
+++ b/tests/fixtures/twblg-upstream/search-drift-zero-matches.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>搜尋結果 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="search-result">
+      <p class="summary">搜尋結果：完全符合「長褲」有 0 筆</p>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/search-structure-changed.html
+++ b/tests/fixtures/twblg-upstream/search-structure-changed.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>搜尋 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="new-ui-results">
+      <p>Found matches: 1</p>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/search-structure-missing-count.html
+++ b/tests/fixtures/twblg-upstream/search-structure-missing-count.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-hant-tw">
+  <head>
+    <title>長褲-搜尋結果</title>
+  </head>
+  <body>
+    <main class="container-fluid">
+      <p>Search results for 長褲</p>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/twblg-upstream/search-structure-missing-def-row.html
+++ b/tests/fixtures/twblg-upstream/search-structure-missing-def-row.html
@@ -1,16 +1,16 @@
 <!doctype html>
 <html lang="zh-hant-tw">
   <head>
-    <title>長褲-用臺灣台語查詞目</title>
+    <title>長褲-搜尋結果</title>
   </head>
   <body>
     <main class="container-fluid">
-      <p class="text-secondary mb-0">完全符合 「長褲」 有2筆</p>
+      <p class="text-secondary mb-0">完全符合 「長褲」 有1筆</p>
       <table class="table">
         <tbody>
           <tr>
-            <th>釋義</th>
-            <td><span>（臺華共同詞 ，無義項）</span></td>
+            <th>其他</th>
+            <td><span>內容</span></td>
           </tr>
         </tbody>
       </table>

--- a/tests/fixtures/twblg-upstream/search-valid-one-match.html
+++ b/tests/fixtures/twblg-upstream/search-valid-one-match.html
@@ -1,11 +1,20 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="zh-hant-tw">
   <head>
-    <title>搜尋結果 - 臺灣閩南語常用詞辭典</title>
+    <title>長褲-用臺灣台語查詞目</title>
   </head>
   <body>
-    <div class="search-result">
-      <p class="summary">搜尋結果：完全符合「長褲」有 1 筆</p>
-    </div>
+    <main class="container-fluid">
+      <p class="text-secondary mb-0">完全符合 「長褲」 有1筆</p>
+      <p class="text-secondary mb-0">部分符合 「長褲」 有1筆</p>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th>釋義</th>
+            <td><span>（臺華共同詞 ，無義項）</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
   </body>
 </html>

--- a/tests/fixtures/twblg-upstream/search-valid-one-match.html
+++ b/tests/fixtures/twblg-upstream/search-valid-one-match.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <title>搜尋結果 - 臺灣閩南語常用詞辭典</title>
+  </head>
+  <body>
+    <div class="search-result">
+      <p class="summary">搜尋結果：完全符合「長褲」有 1 筆</p>
+    </div>
+  </body>
+</html>

--- a/tests/python/test_inject_twblg_variants.py
+++ b/tests/python/test_inject_twblg_variants.py
@@ -37,8 +37,14 @@ class PinnedInjectorTests(unittest.TestCase):
         return tmp, root, pack, manifest
 
     def manifest_entry(self, title):
-        return {"title": title, "T": "ā", "source_entry_url": "https://sutian.moe.edu.tw/entry", "source_search_url": "https://sutian.moe.edu.tw/tshiau/?lui=tai俗"}
-
+        return {
+            "title": title,
+            "T": "ā",
+            "source_entry_url": "https://sutian.moe.edu.tw/entry",
+            "source_search_url": "https://sutian.moe.edu.tw/tshiau/?lui=tai俗",
+            "source_note": "教育部臺灣閩南語常用詞辭典",
+            "verified": "2026-07-17",
+        }
     def test_head_insertion_is_sorted_and_exact(self):
         tmp, root, pack, manifest = self.make_fixture([("%u0041", {"t": "A"}), ("%u0043", {"t": "C"})])
         with tmp:

--- a/tests/unit/twblg-pins-verifier.test.ts
+++ b/tests/unit/twblg-pins-verifier.test.ts
@@ -6,11 +6,13 @@ import {
   calculatePinAge,
   getPinAgeSummary,
   isValidIsoDate,
+  normalizeWhitespace,
   validatePinnedManifest,
   verifyEntryHtml,
   verifySearchHtml,
 } from "../../scripts/lib/twblg-pins.mjs";
 import { verifySinglePin } from "../../commands/verify-twblg-pins-upstream.mjs";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.resolve(__dirname, "../fixtures/twblg-upstream");
 
@@ -102,33 +104,38 @@ describe("twblg-pins provenance and date validation", () => {
     expect(summary.oldestTitle).toBe("長褲");
     expect(summary.oldestAgeDays).toBe(28);
   });
+
+  it("normalizes whitespace and Unicode form cleanly", () => {
+    expect(normalizeWhitespace(" （臺華共同詞 ，無義項） ")).toBe("（臺華共同詞 ，無義項）");
+  });
 });
 
 describe("verifyEntryHtml pure logic", () => {
-  it("returns ok when headword, reading, and no-definition hold", () => {
+  it("returns ok when headword, reading, and negative no-definition hold", () => {
     const html = loadFixture("entry-valid-no-def.html");
     const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
     expect(result.status).toBe("ok");
     expect(result.mismatches).toHaveLength(0);
   });
 
-  it("handles multi-reading alternate entries (e.g. pa-lê/pa-lé)", () => {
+  it("handles multi-reading alternate entries (e.g. NFD pa-lê/pa-lé vs NFC HTML)", () => {
     const html = loadFixture("entry-valid-multi-reading.html");
-    const result = verifyEntryHtml(html, "芭蕾", "pa-lê/pa-lé");
+    // Pass T in NFD to test normalization
+    const result = verifyEntryHtml(html, "芭蕾", "pa-le\u0302/pa-le\u0301");
     expect(result.status).toBe("ok");
     expect(result.mismatches).toHaveLength(0);
   });
 
-  it("detects content drift when a definition appears", () => {
+  it("detects content drift when a definition section appears on the entry page", () => {
     const html = loadFixture("entry-drift-with-definition.html");
     const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
     expect(result.status).toBe("content_drift");
-    expect(result.mismatches.some((m) => m.includes("Definition appeared"))).toBe(true);
+    expect(result.mismatches.some((m) => m.includes("Definition section appeared"))).toBe(true);
   });
 
-  it("detects content drift when readings change/disappear", () => {
+  it("detects content drift when readings change or disappear", () => {
     const html = loadFixture("entry-drift-reading-changed.html");
-    const result = verifyEntryHtml(html, "芭蕾", "pa-lê/pa-lé");
+    const result = verifyEntryHtml(html, "芭蕾", "pa-le\u0302/pa-le\u0301");
     expect(result.status).toBe("content_drift");
     expect(result.mismatches.some((m) => m.includes("Reading missing"))).toBe(true);
   });
@@ -140,41 +147,68 @@ describe("verifyEntryHtml pure logic", () => {
     expect(result.mismatches.some((m) => m.includes("Headword mismatch"))).toBe(true);
   });
 
-  it("distinguishes page structure changes (e.g. missing <h1>)", () => {
+  it("distinguishes page structure changes (missing <h1>)", () => {
     const html = loadFixture("entry-structure-missing-h1.html");
     const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
     expect(result.status).toBe("structure_changed");
-    expect(result.mismatches.some((m) => m.includes("structure changed"))).toBe(true);
+    expect(result.mismatches.some((m) => m.includes("missing <main> or <h1>"))).toBe(true);
+  });
+
+  it("distinguishes page structure changes (missing pronunciation header list)", () => {
+    const html = loadFixture("entry-structure-missing-reading-header.html");
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("structure_changed");
+    expect(
+      result.mismatches.some((m) => m.includes("could not locate pronunciation header list")),
+    ).toBe(true);
   });
 });
 
 describe("verifySearchHtml pure logic", () => {
-  it("returns ok when exactly 1 match is found", () => {
+  it("returns ok when exactly 1 exact match and no-definition marker are found (ignoring partial match counts)", () => {
     const html = loadFixture("search-valid-one-match.html");
     const result = verifySearchHtml(html, "長褲");
     expect(result.status).toBe("ok");
     expect(result.mismatches).toHaveLength(0);
   });
 
-  it("detects content drift when 0 matches found", () => {
+  it("detects content drift when search definition row carries actual definition text instead of no-definition marker", () => {
+    const html = loadFixture("search-drift-def-appeared.html");
+    const result = verifySearchHtml(html, "長褲");
+    expect(result.status).toBe("content_drift");
+    expect(result.mismatches.some((m) => m.includes("does not carry no-definition marker"))).toBe(
+      true,
+    );
+  });
+
+  it("detects content drift when 0 exact matches are found", () => {
     const html = loadFixture("search-drift-zero-matches.html");
     const result = verifySearchHtml(html, "長褲");
     expect(result.status).toBe("content_drift");
     expect(result.mismatches.some((m) => m.includes("expected exactly 1"))).toBe(true);
   });
 
-  it("detects content drift when multiple matches found", () => {
+  it("detects content drift when multiple exact matches are found", () => {
     const html = loadFixture("search-drift-multiple-matches.html");
     const result = verifySearchHtml(html, "長褲");
     expect(result.status).toBe("content_drift");
     expect(result.mismatches.some((m) => m.includes("expected exactly 1"))).toBe(true);
   });
 
-  it("distinguishes page structure changes when summary pattern is missing", () => {
-    const html = loadFixture("search-structure-changed.html");
+  it("distinguishes page structure changes when summary count pattern is missing", () => {
+    const html = loadFixture("search-structure-missing-count.html");
     const result = verifySearchHtml(html, "長褲");
     expect(result.status).toBe("structure_changed");
-    expect(result.mismatches.some((m) => m.includes("Search page structure changed"))).toBe(true);
+    expect(result.mismatches.some((m) => m.includes("could not find '完全符合 ... 有 X 筆'"))).toBe(
+      true,
+    );
+  });
+
+  it("distinguishes page structure changes when definition row is missing from search table", () => {
+    const html = loadFixture("search-structure-missing-def-row.html");
+    const result = verifySearchHtml(html, "長褲");
+    expect(result.status).toBe("structure_changed");
+    expect(result.mismatches.some((m) => m.includes("could not find definition row"))).toBe(true);
   });
 });
 

--- a/tests/unit/twblg-pins-verifier.test.ts
+++ b/tests/unit/twblg-pins-verifier.test.ts
@@ -172,11 +172,20 @@ describe("verifyEntryHtml pure logic", () => {
     expect(result.mismatches.some((m) => m.includes("Headword mismatch"))).toBe(true);
   });
 
-  it("distinguishes page structure changes (missing <h1>)", () => {
+  it("names only the missing <h1> when <main> is present", () => {
     const html = loadFixture("entry-structure-missing-h1.html");
     const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
     expect(result.status).toBe("structure_changed");
-    expect(result.mismatches.some((m) => m.includes("missing <main> or <h1>"))).toBe(true);
+    expect(result.mismatches.some((m) => m.includes("missing <h1> element"))).toBe(true);
+    expect(result.mismatches.some((m) => m.includes("<main>"))).toBe(false);
+  });
+
+  it("names only the missing <main> when <h1> is present", () => {
+    const html = "<html><body><h1>長褲</h1><p>page content without main</p></body></html>";
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("structure_changed");
+    expect(result.mismatches.some((m) => m.includes("missing <main> element"))).toBe(true);
+    expect(result.mismatches.some((m) => m.includes("<h1>"))).toBe(false);
   });
 
   it("distinguishes page structure changes (missing pronunciation header list)", () => {
@@ -234,6 +243,16 @@ describe("verifySearchHtml pure logic", () => {
     const result = verifySearchHtml(html, "長褲");
     expect(result.status).toBe("structure_changed");
     expect(result.mismatches.some((m) => m.includes("could not find definition row"))).toBe(true);
+  });
+
+  it("does not classify a space-containing headword as structure_changed", () => {
+    const html = [
+      "<p>完全符合 「長 褲」 有1筆</p>",
+      "<table><tbody><tr><th>釋義</th><td><span>（臺華共同詞 ，無義項）</span></td></tr></tbody></table>",
+    ].join("");
+    const result = verifySearchHtml(html, "長 褲");
+    expect(result.status).toBe("ok");
+    expect(result.mismatches).toHaveLength(0);
   });
 });
 

--- a/tests/unit/twblg-pins-verifier.test.ts
+++ b/tests/unit/twblg-pins-verifier.test.ts
@@ -27,11 +27,11 @@ describe("twblg-pins provenance and date validation", () => {
     expect(isValidIsoDate("2026-02-29")).toBe(false); // 2026 is not a leap year
     expect(isValidIsoDate("2026-13-01")).toBe(false);
     expect(isValidIsoDate("2026-00-10")).toBe(false);
-    expect(isValidIsoDate("2026-07-32")).toBe(false);
-    expect(isValidIsoDate("invalid-date")).toBe(false);
+    expect(isValidIsoDate("2026-04-31")).toBe(false); // April has 30 days
+    expect(isValidIsoDate("not-a-date")).toBe(false);
     expect(isValidIsoDate("")).toBe(false);
     expect(isValidIsoDate(null)).toBe(false);
-    expect(isValidIsoDate(undefined)).toBe(false);
+    expect(isValidIsoDate(123)).toBe(false);
   });
 
   it("validates pinned manifest structure and required fields", () => {
@@ -40,17 +40,18 @@ describe("twblg-pins provenance and date validation", () => {
         {
           title: "長褲",
           T: "tn̂g-khòo",
-          source_entry_url: "https://sutian.moe.edu.tw/entry",
-          source_search_url: "https://sutian.moe.edu.tw/search",
-          source_note: "教育部臺灣閩南語常用詞辭典",
+          source_entry_url: "https://sutian.moe.edu.tw/zh-hant/su/25638/",
+          source_search_url:
+            "https://sutian.moe.edu.tw/zh-hant/tshiau/?lui=tai_su&tsha=%E9%95%B7%E8%A4%B2",
+          source_note: "MOE 臺灣台語常用詞辭典 su/25638",
           verified: "2026-07-17",
         },
       ],
     };
 
-    const { valid, errors } = validatePinnedManifest(validManifest);
-    expect(valid).toBe(true);
-    expect(errors).toHaveLength(0);
+    const result = validatePinnedManifest(validManifest);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 
   it("fails validation if required fields are missing or date is invalid", () => {
@@ -58,22 +59,25 @@ describe("twblg-pins provenance and date validation", () => {
       entries: [
         {
           title: "長褲",
-          T: "tn̂g-khòo",
-          // missing source_entry_url, source_search_url, source_note
+          // missing T, source_entry_url, source_search_url, source_note
           verified: "2026-99-99",
         },
       ],
     };
 
-    const { valid, errors } = validatePinnedManifest(invalidManifest);
-    expect(valid).toBe(false);
-    expect(errors.length).toBeGreaterThanOrEqual(4);
+    const result = validatePinnedManifest(invalidManifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(4);
+    expect(result.errors.some((e) => e.includes("missing or empty required string field"))).toBe(
+      true,
+    );
+    expect(result.errors.some((e) => e.includes("is not a valid ISO YYYY-MM-DD date"))).toBe(true);
   });
 
   it("calculates pin age correctly", () => {
-    const refDate = new Date("2026-08-14T12:00:00Z");
-    const ageDays = calculatePinAge("2026-07-17", refDate);
-    expect(ageDays).toBe(28);
+    const fakeNow = new Date("2026-08-14T00:00:00Z");
+    const age = calculatePinAge("2026-07-17", fakeNow);
+    expect(age).toBe(28);
 
     const summary = getPinAgeSummary(
       {
@@ -81,28 +85,29 @@ describe("twblg-pins provenance and date validation", () => {
           {
             title: "長褲",
             T: "tn̂g-khòo",
-            source_entry_url: "url1",
-            source_search_url: "url2",
-            source_note: "note",
+            source_entry_url: "https://sutian.moe.edu.tw/zh-hant/su/25638/",
+            source_search_url:
+              "https://sutian.moe.edu.tw/zh-hant/tshiau/?lui=tai_su&tsha=%E9%95%B7%E8%A4%B2",
+            source_note: "MOE 臺灣台語常用詞辭典",
             verified: "2026-07-17",
           },
           {
             title: "芭蕾",
             T: "pa-lê",
-            source_entry_url: "url1",
-            source_search_url: "url2",
-            source_note: "note",
-            verified: "2026-08-01",
+            source_entry_url: "https://sutian.moe.edu.tw/zh-hant/su/23071/",
+            source_search_url: "https://sutian.moe.edu.tw/zh-hant/tshiau/?lui=tai_su&tsha=...",
+            source_note: "MOE 臺灣台語常用詞辭典",
+            verified: "2026-08-14",
           },
         ],
       },
-      refDate,
+      fakeNow,
     );
 
     expect(summary.count).toBe(2);
     expect(summary.oldestDate).toBe("2026-07-17");
-    expect(summary.oldestTitle).toBe("長褲");
     expect(summary.oldestAgeDays).toBe(28);
+    expect(summary.oldestTitle).toBe("長褲");
   });
 
   it("normalizes whitespace and Unicode form cleanly", () => {
@@ -126,18 +131,38 @@ describe("verifyEntryHtml pure logic", () => {
     expect(result.mismatches).toHaveLength(0);
   });
 
+  it("fails when main reading is absent from pronunciation header even if present elsewhere in document", () => {
+    const html = loadFixture("entry-drift-main-reading-only-in-body.html");
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("content_drift");
+    expect(
+      result.mismatches.some((m) => m.includes("Main reading missing from pronunciation header")),
+    ).toBe(true);
+  });
+
+  it("detects content drift when expected alternate reading is missing because 又唸作 section is gone", () => {
+    const html = loadFixture("entry-drift-alt-reading-missing-section.html");
+    const result = verifyEntryHtml(html, "芭蕾", "pa-le\u0302/pa-le\u0301");
+    expect(result.status).toBe("content_drift");
+    expect(
+      result.mismatches.some((m) => m.includes('Alternate reading section ("又唸作") not found')),
+    ).toBe(true);
+  });
+
+  it("detects content drift when expected alternate reading in 又唸作 section does not match", () => {
+    const html = loadFixture("entry-drift-alt-reading-mismatched.html");
+    const result = verifyEntryHtml(html, "芭蕾", "pa-le\u0302/pa-le\u0301");
+    expect(result.status).toBe("content_drift");
+    expect(
+      result.mismatches.some((m) => m.includes('Alternate reading missing from "又唸作" section')),
+    ).toBe(true);
+  });
+
   it("detects content drift when a definition section appears on the entry page", () => {
     const html = loadFixture("entry-drift-with-definition.html");
     const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
     expect(result.status).toBe("content_drift");
     expect(result.mismatches.some((m) => m.includes("Definition section appeared"))).toBe(true);
-  });
-
-  it("detects content drift when readings change or disappear", () => {
-    const html = loadFixture("entry-drift-reading-changed.html");
-    const result = verifyEntryHtml(html, "芭蕾", "pa-le\u0302/pa-le\u0301");
-    expect(result.status).toBe("content_drift");
-    expect(result.mismatches.some((m) => m.includes("Reading missing"))).toBe(true);
   });
 
   it("detects content drift when headword mismatches", () => {

--- a/tests/unit/twblg-pins-verifier.test.ts
+++ b/tests/unit/twblg-pins-verifier.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vite-plus/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  calculatePinAge,
+  getPinAgeSummary,
+  isValidIsoDate,
+  validatePinnedManifest,
+  verifyEntryHtml,
+  verifySearchHtml,
+} from "../../scripts/lib/twblg-pins.mjs";
+import { verifySinglePin } from "../../commands/verify-twblg-pins-upstream.mjs";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = path.resolve(__dirname, "../fixtures/twblg-upstream");
+
+function loadFixture(filename: string): string {
+  return readFileSync(path.join(FIXTURES_DIR, filename), "utf8");
+}
+
+describe("twblg-pins provenance and date validation", () => {
+  it("validates ISO YYYY-MM-DD dates correctly", () => {
+    expect(isValidIsoDate("2026-07-17")).toBe(true);
+    expect(isValidIsoDate("2026-02-28")).toBe(true);
+    expect(isValidIsoDate("2026-02-29")).toBe(false); // 2026 is not a leap year
+    expect(isValidIsoDate("2026-13-01")).toBe(false);
+    expect(isValidIsoDate("2026-00-10")).toBe(false);
+    expect(isValidIsoDate("2026-07-32")).toBe(false);
+    expect(isValidIsoDate("invalid-date")).toBe(false);
+    expect(isValidIsoDate("")).toBe(false);
+    expect(isValidIsoDate(null)).toBe(false);
+    expect(isValidIsoDate(undefined)).toBe(false);
+  });
+
+  it("validates pinned manifest structure and required fields", () => {
+    const validManifest = {
+      entries: [
+        {
+          title: "長褲",
+          T: "tn̂g-khòo",
+          source_entry_url: "https://sutian.moe.edu.tw/entry",
+          source_search_url: "https://sutian.moe.edu.tw/search",
+          source_note: "教育部臺灣閩南語常用詞辭典",
+          verified: "2026-07-17",
+        },
+      ],
+    };
+
+    const { valid, errors } = validatePinnedManifest(validManifest);
+    expect(valid).toBe(true);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("fails validation if required fields are missing or date is invalid", () => {
+    const invalidManifest = {
+      entries: [
+        {
+          title: "長褲",
+          T: "tn̂g-khòo",
+          // missing source_entry_url, source_search_url, source_note
+          verified: "2026-99-99",
+        },
+      ],
+    };
+
+    const { valid, errors } = validatePinnedManifest(invalidManifest);
+    expect(valid).toBe(false);
+    expect(errors.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("calculates pin age correctly", () => {
+    const refDate = new Date("2026-08-14T12:00:00Z");
+    const ageDays = calculatePinAge("2026-07-17", refDate);
+    expect(ageDays).toBe(28);
+
+    const summary = getPinAgeSummary(
+      {
+        entries: [
+          {
+            title: "長褲",
+            T: "tn̂g-khòo",
+            source_entry_url: "url1",
+            source_search_url: "url2",
+            source_note: "note",
+            verified: "2026-07-17",
+          },
+          {
+            title: "芭蕾",
+            T: "pa-lê",
+            source_entry_url: "url1",
+            source_search_url: "url2",
+            source_note: "note",
+            verified: "2026-08-01",
+          },
+        ],
+      },
+      refDate,
+    );
+
+    expect(summary.count).toBe(2);
+    expect(summary.oldestDate).toBe("2026-07-17");
+    expect(summary.oldestTitle).toBe("長褲");
+    expect(summary.oldestAgeDays).toBe(28);
+  });
+});
+
+describe("verifyEntryHtml pure logic", () => {
+  it("returns ok when headword, reading, and no-definition hold", () => {
+    const html = loadFixture("entry-valid-no-def.html");
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("ok");
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("handles multi-reading alternate entries (e.g. pa-lê/pa-lé)", () => {
+    const html = loadFixture("entry-valid-multi-reading.html");
+    const result = verifyEntryHtml(html, "芭蕾", "pa-lê/pa-lé");
+    expect(result.status).toBe("ok");
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("detects content drift when a definition appears", () => {
+    const html = loadFixture("entry-drift-with-definition.html");
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("content_drift");
+    expect(result.mismatches.some((m) => m.includes("Definition appeared"))).toBe(true);
+  });
+
+  it("detects content drift when readings change/disappear", () => {
+    const html = loadFixture("entry-drift-reading-changed.html");
+    const result = verifyEntryHtml(html, "芭蕾", "pa-lê/pa-lé");
+    expect(result.status).toBe("content_drift");
+    expect(result.mismatches.some((m) => m.includes("Reading missing"))).toBe(true);
+  });
+
+  it("detects content drift when headword mismatches", () => {
+    const html = loadFixture("entry-drift-headword-mismatch.html");
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("content_drift");
+    expect(result.mismatches.some((m) => m.includes("Headword mismatch"))).toBe(true);
+  });
+
+  it("distinguishes page structure changes (e.g. missing <h1>)", () => {
+    const html = loadFixture("entry-structure-missing-h1.html");
+    const result = verifyEntryHtml(html, "長褲", "tn̂g-khòo");
+    expect(result.status).toBe("structure_changed");
+    expect(result.mismatches.some((m) => m.includes("structure changed"))).toBe(true);
+  });
+});
+
+describe("verifySearchHtml pure logic", () => {
+  it("returns ok when exactly 1 match is found", () => {
+    const html = loadFixture("search-valid-one-match.html");
+    const result = verifySearchHtml(html, "長褲");
+    expect(result.status).toBe("ok");
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("detects content drift when 0 matches found", () => {
+    const html = loadFixture("search-drift-zero-matches.html");
+    const result = verifySearchHtml(html, "長褲");
+    expect(result.status).toBe("content_drift");
+    expect(result.mismatches.some((m) => m.includes("expected exactly 1"))).toBe(true);
+  });
+
+  it("detects content drift when multiple matches found", () => {
+    const html = loadFixture("search-drift-multiple-matches.html");
+    const result = verifySearchHtml(html, "長褲");
+    expect(result.status).toBe("content_drift");
+    expect(result.mismatches.some((m) => m.includes("expected exactly 1"))).toBe(true);
+  });
+
+  it("distinguishes page structure changes when summary pattern is missing", () => {
+    const html = loadFixture("search-structure-changed.html");
+    const result = verifySearchHtml(html, "長褲");
+    expect(result.status).toBe("structure_changed");
+    expect(result.mismatches.some((m) => m.includes("Search page structure changed"))).toBe(true);
+  });
+});
+
+describe("verifySinglePin with mock fetch", () => {
+  it("orchestrates passing entry and search verification", async () => {
+    const entryHtml = loadFixture("entry-valid-no-def.html");
+    const searchHtml = loadFixture("search-valid-one-match.html");
+
+    const mockFetch = async (input: string | URL | Request) => {
+      const urlStr =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (urlStr.includes("entry")) {
+        return { ok: true, status: 200, text: async () => entryHtml } as unknown as Response;
+      }
+      return { ok: true, status: 200, text: async () => searchHtml } as unknown as Response;
+    };
+
+    const entry = {
+      title: "長褲",
+      T: "tn̂g-khòo",
+      source_entry_url: "https://sutian.moe.edu.tw/entry",
+      source_search_url: "https://sutian.moe.edu.tw/search",
+      source_note: "教育部臺灣閩南語常用詞辭典",
+      verified: "2026-07-17",
+    };
+
+    const report = await verifySinglePin(entry, mockFetch as unknown as typeof fetch);
+    expect(report.status).toBe("ok");
+    expect(report.details).toHaveLength(0);
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    const mockFetch = async () => {
+      throw new Error("Network unreachable");
+    };
+
+    const entry = {
+      title: "長褲",
+      T: "tn̂g-khòo",
+      source_entry_url: "https://sutian.moe.edu.tw/entry",
+      source_search_url: "https://sutian.moe.edu.tw/search",
+      source_note: "教育部臺灣閩南語常用詞辭典",
+      verified: "2026-07-17",
+    };
+
+    const report = await verifySinglePin(entry, mockFetch as unknown as typeof fetch);
+    expect(report.status).toBe("fetch_error");
+    expect(report.details.some((d) => d.includes("Network unreachable"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **Upstream Network Verifier (`commands/verify-twblg-pins-upstream.mjs`, `scripts/lib/twblg-pins.mjs`)**:
  - Implements an explicitly invoked verifier that fetches live official MOE dictionary entries and searches on `sutian.moe.edu.tw`.
  - Asserts headword presence, exact readings (including slash-separated alternates), no-definition marker (absence of 釋義 section), and exactly 1 exact search match.
  - Distinguishes three distinct outcomes: `ok` (claim holds), `content_drift` (upstream data changed), and `structure_changed` (page HTML structure changed).
  - Supports `--update-verified` flag to refresh ISO dates only if all pins pass.
- **Offline Provenance Hardening**:
  - `scripts/inject-twblg-pinned-entries.py` and `scripts/check-dictionary-data.mjs` validate that every manifest entry contains `source_entry_url`, `source_search_url`, `source_note`, and a valid ISO `YYYY-MM-DD` `verified` date.
  - Logs pin count and oldest pin age in days as informational output without failing builds.
- **Scheduling & Documentation**:
  - Added `.github/workflows/verify-twblg-pins.yml` to run weekly and via `workflow_dispatch` (never on `push` or `pull_request`).
  - Documented the verification mechanism, outcome classifications, and explicit rule excluding it from PR CI in `AGENTS.md`.
- **Tests**:
  - Added 16 deterministic unit tests (`tests/unit/twblg-pins-verifier.test.ts`) using saved HTML fixtures (`tests/fixtures/twblg-upstream/`).

## Test Plan
- [x] `vp run twblg-pins:verify-upstream` against live MOE dictionary (all 3 pins pass).
- [x] `vp run twblg-pins:check`
- [x] `vp run check:data`
- [x] `vp check`
- [x] `vp run typecheck`
- [x] `vp test tests/unit/twblg-pins-verifier.test.ts`
- [x] `vp run test:unit --coverage`
- [x] `vp run test:integration`
- [x] `python3 tests/python/test_inject_twblg_variants.py`