### PR TITLE
fix(font): reorder search input font stack to prevent iOS WKWebView tofu

### DIFF
--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -327,11 +327,11 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 			height: 1.8em;
 			box-sizing: border-box;
 			padding: 4px 8px;
-			font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, MOEDICT, "TW-Kai-98_1", "標楷體", serif;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif, MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 		}
 
 		html.moe-capacitor .query-box input.query {
-			font-family: "Biaodian Pro Serif CNS", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif, "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif, "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 		}
 
 		.query-box input.query::placeholder {

--- a/src/index.css
+++ b/src/index.css
@@ -136,16 +136,8 @@ body {
   font-size: 16px;
   line-height: 1.4;
   font-family:
-    "Biaodian Pro Serif CNS",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    system-ui,
-    sans-serif,
-    MOEDICT,
-    "TW-Kai-98_1",
-    "標楷體",
-    serif;
+    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif,
+    MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 }
 
 .fulltext-search-input:focus {
@@ -156,17 +148,8 @@ body {
 
 html.moe-capacitor .fulltext-search-input {
   font-family:
-    "Biaodian Pro Serif CNS",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    system-ui,
-    sans-serif,
-    "MOE EduKai Android",
-    MOEDICT,
-    "TW-Kai-98_1",
-    "標楷體",
-    serif;
+    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif,
+    "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 }
 
 .fulltext-search-icon {

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -2490,7 +2490,7 @@ test.describe("@romanization search input font-family stack does not lead with B
       (el) => getComputedStyle(el).fontFamily,
     );
 
-    expect(navbarFontFamily.trim().startsWith('"Biaodian Pro Serif CNS"')).toBe(false);
-    expect(sidebarFontFamily.trim().startsWith('"Biaodian Pro Serif CNS"')).toBe(false);
+    expect(navbarFontFamily.trim()).not.toMatch(/^['"]?Biaodian Pro Serif CNS['"]?\s*(,|$)/);
+    expect(sidebarFontFamily.trim()).not.toMatch(/^['"]?Biaodian Pro Serif CNS['"]?\s*(,|$)/);
   });
 });

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -2472,3 +2472,25 @@ test.describe("charimg-result romanize checkbox (RESCOPE #169)", () => {
     expect(twitterImage).toMatch(/\.png$/);
   });
 });
+
+test.describe("@romanization search input font-family stack does not lead with Biaodian Pro Serif CNS", () => {
+  test("computed font-family on WebKit / Desktop Safari resolves system font before Biaodian Pro Serif CNS", async ({
+    page,
+  }) => {
+    await page.goto("/%E8%90%8C");
+    await waitForAppReady(page, "dictionary");
+
+    const navbarSearchInput = page.locator(".fulltext-search-input").first();
+    const sidebarQueryInput = page.locator(".query-box input.query").first();
+
+    const navbarFontFamily = await navbarSearchInput.evaluate(
+      (el) => getComputedStyle(el).fontFamily,
+    );
+    const sidebarFontFamily = await sidebarQueryInput.evaluate(
+      (el) => getComputedStyle(el).fontFamily,
+    );
+
+    expect(navbarFontFamily.trim().startsWith('"Biaodian Pro Serif CNS"')).toBe(false);
+    expect(sidebarFontFamily.trim().startsWith('"Biaodian Pro Serif CNS"')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Reorders font-family stack in search input selectors (`.fulltext-search-input`, `.query-box input.query`, and their `html.moe-capacitor` variants) so system fonts (`-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui`) precede `"Biaodian Pro Serif CNS"`.
- Matches the font stack ordering used elsewhere in the codebase (`.fulltext-search-result-title`, autocomplete dropdown items).
- Fixes iOS WKWebView tofu boxes on search placeholders (多語檢索) and input text caused by form controls binding to the unicode-range-restricted Biaodian `@font-face` definition and failing to fall through to `-apple-system`.
- Preserves all other families in the stacks (including `"MOE EduKai Android"` and `"Biaodian Pro Serif CNS"`).
- Leaves headword/title selectors (`.result .entry .title`) untouched.
- Adds an e2e WebKit / Chromium guard test asserting search input computed `font-family` does not begin with `"Biaodian Pro Serif CNS"`.

## Trade-off / Disclosure
- CJK punctuation typed into the search box currently picks up the Han.css punctuation face and will now use the system face instead.

## Test plan
- `vp run typecheck` passes cleanly.
- `vp check` passes cleanly (0 errors, 0 warnings).
- `vp run test:unit --coverage` passes with 100% statements/branches/functions/lines.
- `vp run test:integration` passes.
- `E2E_SKIP_BUILD=1 vp exec playwright test tests/e2e/dictionary.spec.ts -g "search input font-family stack"` passes on Chromium and WebKit (`webkit-romanization`).