### PR TITLE
fix(font): fall back Same-Origin MOEDICT to bundled assets-legacy

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -75,13 +75,20 @@ body {
    *before* the bare MOEDICT family in critical font stacks ensures the
    title font is resolved same-origin and is immune to that CORS cache state.
    The ?v=20260713-cors query suffix busts any old edge cache key for these
-   paths; it does not affect font bytes. */
+   paths; it does not affect font bytes.
+   Each format then lists /assets-legacy/fonts/MOEDICT.* (no query) as a
+   second src: Capacitor stages those files locally, and a query string
+   cannot match a bundled file. Web never reaches the fallback because
+   the Worker path succeeds first. No extra font bytes are copied. */
 @font-face {
   font-family: "MOEDICT Same-Origin";
   src:
     url("/assets/fonts/MOEDICT.woff2?v=20260713-cors") format("woff2"),
+    url("/assets-legacy/fonts/MOEDICT.woff2") format("woff2"),
     url("/assets/fonts/MOEDICT.otf?v=20260713-cors") format("opentype"),
-    url("/assets/fonts/MOEDICT.woff?v=20260713-cors") format("woff");
+    url("/assets-legacy/fonts/MOEDICT.otf") format("opentype"),
+    url("/assets/fonts/MOEDICT.woff?v=20260713-cors") format("woff"),
+    url("/assets-legacy/fonts/MOEDICT.woff") format("woff");
   font-display: swap;
   font-style: normal;
   font-weight: 400;


### PR DESCRIPTION
## Summary
- Extends the existing `"MOEDICT Same-Origin"` `@font-face` in `src/index.css` so each format lists the Worker same-origin path first, then the already-bundled Capacitor path:
  - `url("/assets/fonts/MOEDICT.woff2?v=20260713-cors")` then `url("/assets-legacy/fonts/MOEDICT.woff2")` (same pairing for `.otf` / `.woff`)
- The `?v=20260713-cors` query stays on the Worker URLs only. It cannot match a bundled file, so the fallbacks omit it.
- No font bytes are copied. `MOEDICT.ttf` licence is unconfirmed (`src/utils/image-generation.ts`); this only points at the copy the app already stages under `/assets-legacy/fonts/`.

## Selectors that actually use this family
Only the title / zhuyin stacks, not search inputs:
1. `.result .entry .title` (via `"MOEDICT Same-Origin"` after `--title-leading-family`)
2. `.result .entry .title hruby.rightangle ru[zhuyin] zhuyin, yin, diao`
3. `html.moe-capacitor .result .entry .title hruby.rightangle ru[zhuyin] zhuyin, yin, diao` (EduKai first, then this alias)

Bare `MOEDICT` (legacy `styles.css` `@font-face` with relative `fonts/MOEDICT.*`) is a different family and is unchanged.

## Why this shape
- **Web:** first `src` still succeeds; fallback is never requested; same-origin CORS strategy and the existing e2e assertion on `/assets/fonts/MOEDICT.woff2?v=20260713-cors` remain intact.
- **Capacitor:** first `src` 404s once, second resolves against files already staged at `/assets-legacy/fonts/`. Today's three failed requests become one, and the face can load.
- `@font-face` cannot be scoped with `html.moe-capacitor`, so a class override would not have worked.

## End-to-end proof this PR does not own
The WebView actually loading the fallback instead of failing three times requires an app rebuild + logcat check. Someone else owns that half. This PR is the source-side change only.

## Test plan
- `vp run typecheck` passes.
- `vp check` passes (0 errors; pre-existing `no-control-regex` warning in `scripts/lib/r2-upload.mjs` only).
- `vp run test:unit --coverage` — 82 files / 2149 tests, 100% statements/branches/functions/lines.
- `vp run test:integration` — 9 files / 141 tests.
- Existing e2e `tests/e2e/dictionary.spec.ts` "MOEDICT Same-Origin font and 黃 length-3 tone geometry" still passes unmodified (chromium).
- **Do not deploy.** Capacitor-only path; web is unchanged when the first src succeeds.