### PR TITLE
fix: drop Biaodian from iOS search input stacks

### DIFF
--- a/src/components/InlineStyles.tsx
+++ b/src/components/InlineStyles.tsx
@@ -327,11 +327,7 @@ export function InlineStyles({ r2Endpoint, onReady }: InlineStylesProps) {
 			height: 1.8em;
 			box-sizing: border-box;
 			padding: 4px 8px;
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif, MOEDICT, "TW-Kai-98_1", "標楷體", serif;
-		}
-
-		html.moe-capacitor .query-box input.query {
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif, "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang TC", "Microsoft JhengHei", "Heiti TC", sans-serif;
 		}
 
 		.query-box input.query::placeholder {

--- a/src/index.css
+++ b/src/index.css
@@ -135,21 +135,20 @@ body {
   color: #333;
   font-size: 16px;
   line-height: 1.4;
+  /* System CJK before any @font-face. iOS WKWebView form controls bind to the
+     first declared webfont and do not unicode-range-fall through, so a
+     Biaodian-first (or Biaodian-before-sans-serif) stack paints BMP CJK as
+     .notdef tofu. #166 reordered to -apple-system first, but San Francisco
+     has no CJK, so Biaodian was still the first webfont asked for 萌. */
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif,
-    MOEDICT, "TW-Kai-98_1", "標楷體", serif;
+    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang TC", "Microsoft JhengHei",
+    "Heiti TC", sans-serif;
 }
 
 .fulltext-search-input:focus {
   outline: none;
   border-color: #74b2e2;
   box-shadow: 0 0 0 2px rgba(116, 178, 226, 0.18);
-}
-
-html.moe-capacitor .fulltext-search-input {
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif,
-    "MOE EduKai Android", MOEDICT, "TW-Kai-98_1", "標楷體", serif;
 }
 
 .fulltext-search-icon {

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -2503,12 +2503,13 @@ test.describe("@romanization search input font-family stack excludes Biaodian we
       return link?.sheet != null;
     });
 
-    const assertSafeInputStack = async (selector: string, expectedValue?: string) => {
+    const assertSafeInputStack = async (
+      selector: string,
+      expected: { value: string; placeholder: string },
+    ) => {
       const inputs = page.locator(selector);
       const count = await inputs.count();
       expect(count, `${selector} must exist`).toBeGreaterThan(0);
-      const snapshots: Array<{ fontFamily: string; value: string; placeholder: string | null }> =
-        [];
       for (let i = 0; i < count; i += 1) {
         const snapshot = await inputs.nth(i).evaluate((el) => {
           const inputEl = el as HTMLInputElement;
@@ -2525,24 +2526,18 @@ test.describe("@romanization search input font-family stack excludes Biaodian we
           snapshot.fontFamily,
           `${selector}[${i}] includes a CJK system face or generic`,
         ).toMatch(/PingFang TC|Heiti TC|Microsoft JhengHei|sans-serif/i);
-        if (expectedValue !== undefined) {
-          expect(snapshot.value, `${selector}[${i}] value`).toBe(expectedValue);
-        }
-        snapshots.push(snapshot);
+        expect(snapshot.value, `${selector}[${i}] value`).toBe(expected.value);
+        expect(snapshot.placeholder, `${selector}[${i}] placeholder`).toBe(expected.placeholder);
       }
-      return snapshots[0]!;
     };
 
-    const navbar = await assertSafeInputStack("#nav-fulltext-search");
-    expect(navbar.placeholder).toBe("多語檢索");
-    expect(navbar.value).toBe("");
-    const query = await assertSafeInputStack("#query", "萌");
-    expect(query.placeholder).toBe("請輸入欲查詢的字詞");
+    await assertSafeInputStack("#nav-fulltext-search", { value: "", placeholder: "多語檢索" });
+    await assertSafeInputStack("#query", { value: "萌", placeholder: "請輸入欲查詢的字詞" });
 
     await page.evaluate(() => {
       document.documentElement.classList.add("moe-capacitor", "moe-ios");
     });
-    await assertSafeInputStack("#nav-fulltext-search");
-    await assertSafeInputStack("#query", "萌");
+    await assertSafeInputStack("#nav-fulltext-search", { value: "", placeholder: "多語檢索" });
+    await assertSafeInputStack("#query", { value: "萌", placeholder: "請輸入欲查詢的字詞" });
   });
 });

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Page, Route } from "@playwright/test";
 import { expect, test } from "./_fixtures";
 import { waitForAppReady } from "./readiness";
@@ -2473,24 +2476,73 @@ test.describe("charimg-result romanize checkbox (RESCOPE #169)", () => {
   });
 });
 
-test.describe("@romanization search input font-family stack does not lead with Biaodian Pro Serif CNS", () => {
-  test("computed font-family on WebKit / Desktop Safari resolves system font before Biaodian Pro Serif CNS", async ({
+test.describe("@romanization search input font-family stack excludes Biaodian webfonts", () => {
+  test("WebKit computed font-family with real legacy CSS has no Biaodian before system CJK", async ({
     page,
   }) => {
+    const stylesCss = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "..", "data", "assets", "styles.css"),
+      "utf-8",
+    );
+    const fulfillLegacyCss = (route: Route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/css; charset=utf-8",
+        headers: { "Access-Control-Allow-Origin": "*", "Cache-Control": "no-store" },
+        body: stylesCss,
+      });
+    await page.route("https://r2-assets.test.local/styles.css", fulfillLegacyCss);
+    await page.route("https://r2-assets.test.local/styles.css?*", fulfillLegacyCss);
+    await page.route("**/assets/styles.css", fulfillLegacyCss);
+    await page.route("**/assets/styles.css?*", fulfillLegacyCss);
+
     await page.goto("/%E8%90%8C");
     await waitForAppReady(page, "dictionary");
+    await page.waitForFunction(() => {
+      const link = document.querySelector<HTMLLinkElement>('link[data-asset-id="styles-css"]');
+      return link?.sheet != null;
+    });
 
-    const navbarSearchInput = page.locator(".fulltext-search-input").first();
-    const sidebarQueryInput = page.locator(".query-box input.query").first();
+    const assertSafeInputStack = async (selector: string, expectedValue?: string) => {
+      const inputs = page.locator(selector);
+      const count = await inputs.count();
+      expect(count, `${selector} must exist`).toBeGreaterThan(0);
+      const snapshots: Array<{ fontFamily: string; value: string; placeholder: string | null }> =
+        [];
+      for (let i = 0; i < count; i += 1) {
+        const snapshot = await inputs.nth(i).evaluate((el) => {
+          const inputEl = el as HTMLInputElement;
+          return {
+            fontFamily: getComputedStyle(inputEl).fontFamily,
+            value: inputEl.value,
+            placeholder: inputEl.getAttribute("placeholder"),
+          };
+        });
+        expect(snapshot.fontFamily, `${selector}[${i}] computed font-family`).not.toMatch(
+          /Biaodian/i,
+        );
+        expect(
+          snapshot.fontFamily,
+          `${selector}[${i}] includes a CJK system face or generic`,
+        ).toMatch(/PingFang TC|Heiti TC|Microsoft JhengHei|sans-serif/i);
+        if (expectedValue !== undefined) {
+          expect(snapshot.value, `${selector}[${i}] value`).toBe(expectedValue);
+        }
+        snapshots.push(snapshot);
+      }
+      return snapshots[0]!;
+    };
 
-    const navbarFontFamily = await navbarSearchInput.evaluate(
-      (el) => getComputedStyle(el).fontFamily,
-    );
-    const sidebarFontFamily = await sidebarQueryInput.evaluate(
-      (el) => getComputedStyle(el).fontFamily,
-    );
+    const navbar = await assertSafeInputStack("#nav-fulltext-search");
+    expect(navbar.placeholder).toBe("多語檢索");
+    expect(navbar.value).toBe("");
+    const query = await assertSafeInputStack("#query", "萌");
+    expect(query.placeholder).toBe("請輸入欲查詢的字詞");
 
-    expect(navbarFontFamily.trim()).not.toMatch(/^['"]?Biaodian Pro Serif CNS['"]?\s*(,|$)/);
-    expect(sidebarFontFamily.trim()).not.toMatch(/^['"]?Biaodian Pro Serif CNS['"]?\s*(,|$)/);
+    await page.evaluate(() => {
+      document.documentElement.classList.add("moe-capacitor", "moe-ios");
+    });
+    await assertSafeInputStack("#nav-fulltext-search");
+    await assertSafeInputStack("#query", "萌");
   });
 });


### PR DESCRIPTION
## Cause

PR #166 reordered the four search/query input stacks so they no longer *lead* with `Biaodian Pro Serif CNS`. That reorder is live in the Capacitor bundle. The tofu is unchanged.

A WebKit Playwright probe with the **real** `data/assets/styles.css` injected (same `page.route` technique as `legacy-styles-regression.spec.ts`) shows the #id-selector / late-legacy-sheet hypothesis is **wrong**:

- `#query` and `#nav-fulltext-search` have **no** `font-family` rule in the legacy sheet.
- Computed `font-family` after legacy CSS loads is still the #166 src-side stack.
- Capacitor winner is `html.moe-capacitor .fulltext-search-input` / `html.moe-capacitor .query-box input.query`.

Verbatim WebKit computed values **before this fix** (legacy CSS applied):

```
-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Biaodian Pro Serif CNS", sans-serif, "MOE EduKai Android", MOEDICT, TW-Kai-98_1, 標楷體, serif
```

Field contents (BMP CJK, not PUA):

| Field | id | value | placeholder |
| --- | --- | --- | --- |
| navbar search | `nav-fulltext-search` | `""` | `多語檢索` (U+591A U+8A9E U+6AA2 U+7D22) |
| query | `query` | `萌` (U+840C) | `請輸入欲查詢的字詞` |

The query box shows **one** tofu because its value is the single character `萌` — the same character that renders correctly in the title a few hundred pixels below. The navbar shows two boxes because the empty input paints the 4-character placeholder `多語檢索`, clipped by the mobile field width.

Why #166 was insufficient: `-apple-system` / San Francisco has **no CJK**. iOS WKWebView form controls then bind to the first *declared webfont* (`Biaodian Pro Serif CNS`), whose `@font-face` `unicode-range` is PUA + punctuation only, and do not fall through that family to `sans-serif`. Result: `.notdef` tofu.

The #166 guard only asserted that the computed string does not *begin* with Biaodian, and it never loaded the legacy sheet. It was green on a document the real app never has.

## Fix

Src-side only. `data/assets/styles.css` is untouched.

Replace the input stacks with system CJK faces and drop the restricted webfonts:

```css
-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang TC", "Microsoft JhengHei", "Heiti TC", sans-serif
```

The now-identical `html.moe-capacitor` overrides were removed.

## Guard

`tests/e2e/dictionary.spec.ts` (`@romanization`, so WebKit CI runs it):

- injects the real legacy stylesheet via `page.route`
- waits until `link[data-asset-id="styles-css"]` has a sheet
- asserts **every** `#nav-fulltext-search` / `#query` (desktop + hidden mobile clone) has no `Biaodian` in computed `font-family`, and includes a CJK system face / `sans-serif`
- checks `#query` value is `萌` and the navbar placeholder is `多語檢索`
- repeats after adding `html.moe-capacitor.moe-ios`

## Proved / unproven

**Proved:** winning declarations, computed stacks, field codepoints, and that the new stack wins even with legacy CSS applied (Chromium + WebKit Playwright).

**Unproven:** iOS Simulator screenshot with real glyphs. Someone else must rebuild/reinstall the Capacitor app after this merges. Do not treat a green e2e as device proof.

## Gates

- `vp run typecheck` — pass
- `vp check` — pass (pre-existing `no-control-regex` warning in `scripts/lib/r2-upload.mjs`)
- `vp run test:unit` — 2149 passed
- `vp run test:integration` — 141 passed
- e2e `dictionary.spec.ts` `-g "search input font-family"` — chromium + webkit-romanization passed

Do not deploy.