### PR TITLE
docs: stop claiming an unverified iOS input-tofu mechanism

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -142,11 +142,9 @@ body {
   color: #333;
   font-size: 16px;
   line-height: 1.4;
-  /* System CJK before any @font-face. iOS WKWebView form controls bind to the
-     first declared webfont and do not unicode-range-fall through, so a
-     Biaodian-first (or Biaodian-before-sans-serif) stack paints BMP CJK as
-     .notdef tofu. #166 reordered to -apple-system first, but San Francisco
-     has no CJK, so Biaodian was still the first webfont asked for 萌. */
+  /* Names real CJK system families, not a PUA-only webfont; defensible on
+     its own merits. Simulator tofu is those iOS 26.x runtimes shipping no
+     Chinese system fonts. Whether any real device was ever affected is unverified. */
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang TC", "Microsoft JhengHei",
     "Heiti TC", sans-serif;

--- a/src/index.css
+++ b/src/index.css
@@ -143,8 +143,8 @@ body {
   font-size: 16px;
   line-height: 1.4;
   /* Names real CJK system families, not a PUA-only webfont; defensible on
-     its own merits. Simulator tofu seen here is some iOS Simulator images
-     shipping no Chinese system fonts. Whether any real device was ever affected is unverified. */
+     its own merits. The iOS 26.3/26.4/26.5 Simulator runtimes checked here
+     ship no Chinese system fonts. Whether any real device was ever affected is unverified. */
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang TC", "Microsoft JhengHei",
     "Heiti TC", sans-serif;

--- a/src/index.css
+++ b/src/index.css
@@ -143,8 +143,8 @@ body {
   font-size: 16px;
   line-height: 1.4;
   /* Names real CJK system families, not a PUA-only webfont; defensible on
-     its own merits. Simulator tofu is those iOS 26.x runtimes shipping no
-     Chinese system fonts. Whether any real device was ever affected is unverified. */
+     its own merits. Simulator tofu seen here is some iOS Simulator images
+     shipping no Chinese system fonts. Whether any real device was ever affected is unverified. */
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "PingFang TC", "Microsoft JhengHei",
     "Heiti TC", sans-serif;

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -2478,8 +2478,7 @@ test.describe("charimg-result romanize checkbox (RESCOPE #169)", () => {
 
 // Guards the CSS cascade on desktop WebKit: with the real legacy stylesheet
 // injected, search/query inputs must not compute a Biaodian family. This
-// cannot detect a missing system font on a device; it passed while iOS
-// Simulator inputs still painted CJK as tofu.
+// cannot detect a missing system font on a device.
 test.describe("@romanization search input font-family cascade on desktop WebKit", () => {
   test("desktop WebKit computed font-family with real legacy CSS has no Biaodian", async ({
     page,

--- a/tests/e2e/dictionary.spec.ts
+++ b/tests/e2e/dictionary.spec.ts
@@ -2476,8 +2476,12 @@ test.describe("charimg-result romanize checkbox (RESCOPE #169)", () => {
   });
 });
 
-test.describe("@romanization search input font-family stack excludes Biaodian webfonts", () => {
-  test("WebKit computed font-family with real legacy CSS has no Biaodian before system CJK", async ({
+// Guards the CSS cascade on desktop WebKit: with the real legacy stylesheet
+// injected, search/query inputs must not compute a Biaodian family. This
+// cannot detect a missing system font on a device; it passed while iOS
+// Simulator inputs still painted CJK as tofu.
+test.describe("@romanization search input font-family cascade on desktop WebKit", () => {
+  test("desktop WebKit computed font-family with real legacy CSS has no Biaodian", async ({
     page,
   }) => {
     const stylesCss = readFileSync(


### PR DESCRIPTION
## Why

#166 / #168 comments and the #168 WebKit guard described, as established fact, that iOS WKWebView form controls bind to the first declared webfont and skip unicode-range fallback. That mechanism was inferred, never demonstrated, and a later simulator probe undercuts its predictive value: the same tofu appears with no webfont in the stack at all.

## What is established

- The shipped input stack names real CJK system families rather than a PUA-only webfont. That choice is defensible on its own merits.
- The tofu observed on this machine's iOS Simulator is explained by those iOS 26.3 / 26.4 / 26.5 runtimes shipping no Chinese system fonts (no PingFang, Heiti, Songti, Kaiti, Noto Sans CJK). Japanese Hiragino and Korean Apple SD Gothic Neo are present.
- The entry body still renders because Han.css `@font-face "Han Heiti CNS"` uses `local('Hiragino Kaku Gothic ProN')` across the CJK unicode-range, and that local name exists. Inputs inherit neither that face nor the bundled MOEDICT title webfont.
- Whether any **real** iOS device was ever affected remains unverified. No real device is available on this machine.

## Change

Comments / test descriptions only. No `font-family` declaration, assertion, or behaviour change. `data/assets/styles.css` untouched. `src/components/InlineStyles.tsx` has no parallel mechanism comment.

- `src/index.css` above `.fulltext-search-input`: record the established / unverified split.
- `tests/e2e/dictionary.spec.ts`: the `@romanization` guard now says it checks the CSS cascade on desktop WebKit and cannot detect a missing system font on a device. Assertions unchanged.

## Gates

- `vp run typecheck` — pass
- `vp check` — pass (pre-existing `no-control-regex` warning in `scripts/lib/r2-upload.mjs`)
- `vp run test:unit` — 82 files / 2149 tests passed
- `vp run test:integration` — 9 files / 141 tests passed
- `vp exec playwright test --project=webkit-romanization tests/e2e/dictionary.spec.ts -g "desktop WebKit computed font-family"` — 1 passed

Do not deploy.